### PR TITLE
docs: show Demo link on mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,7 @@
     .nav-links .gh:hover { border-color: var(--magenta); background: var(--magenta-soft); }
     .nav-links .gh svg { display: block; }
     @media (max-width: 640px) {
-      .nav-links a:not(.gh) { display: none; }
+      .nav-links a:not(.gh):not(#navVideo) { display: none; }
     }
 
     /* ---------- video dialog ---------- */


### PR DESCRIPTION
Keep the Demo nav entry visible at <=640px so users on phones can open
the demo dialog. Install/Commands stay hidden to keep the bar compact.