### PR TITLE
docs: refresh landing page from source

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -777,7 +777,7 @@
     <section class="hero" aria-labelledby="hero-title">
       <div class="wrap hero-grid">
         <div>
-          <span class="pill"><span class="pulse" aria-hidden="true"></span> Local-first</span>
+          <span class="pill"><span class="pulse" aria-hidden="true"></span> Local-first · MIT · v0.9.0</span>
           <h1 id="hero-title" class="headline">
             Local agents,<br />the <em>easy</em> way.
           </h1>
@@ -1080,6 +1080,7 @@ Ask before anything destructive or anything needing sudo. If a step fails, show 
           <li class="cmd-row"><code translate="no">locca install-llama</code><span>Download / update a prebuilt llama.cpp binary into <code translate="no" style="font-family:var(--mono)">~/.locca/bin</code>. Auto-detects backend.</span></li>
           <li class="cmd-row"><code translate="no">locca config</code><span>View / edit settings — get, set, reset, list, path.</span></li>
           <li class="cmd-row"><code translate="no">locca setup</code><span>Re-run the setup wizard.</span></li>
+          <li class="cmd-row"><code translate="no">locca help</code><span>Print usage information and list all available commands.</span></li>
         </ul>
       </div>
     </section>


### PR DESCRIPTION
Automated content sync of `docs/index.html` against current source of truth.

## Changes

- **version pill**: added `· MIT · v0.9.0` (pill previously only read `Local-first`; package.json is at `0.9.0`)
- **commands**: added `locca help` row (synthetic command wired in `src/cli.ts` line 37; was missing from the `.cmd-grid`)
- **install**: no change (`npm install -g @zeiq/locca` matches README Quickstart)
- **ctx table**: no change (no `.ctx-table` section exists in the page; regex bands and values in `ctxForModel()` match the task spec exactly)
- **GitHub links**: no change (all links already point to `perminder-klair/locca`)

## Notes

- `npm run build` was already broken on `main` before this change (missing `node_modules`; `@types/node` and other deps not installed in the environment). Build step skipped per task instructions.
- HTML sanity check passed: `python3 -c "import html.parser …" → ok`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnuAki8bvzNcFRuNwpWVyc)_