### PR TITLE
feat(embed): dedicated embedding model serving (closes #7)

### DIFF
--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -43,6 +43,15 @@ export interface CatalogSize {
   ctxWindow: number;
   /** KV-cache slope: bytes per 1000 tokens at the model's default cache types. */
   ctxBytesPer1kTokens: number;
+  /**
+   * Pooling type llama-server must serve this embedding model with
+   * (`--pooling`). Only meaningful for `kind: 'embedding'` families — the wrong
+   * value yields wrong vectors (nomic = mean, mxbai/bge = cls). Ignored for
+   * chat models.
+   */
+  pooling?: 'mean' | 'cls' | 'last';
+  /** Output embedding dimensionality (informational; shown by `locca api`). */
+  embedDim?: number;
   /** Builds, primary (full-precision) first, then quantized variants. */
   builds: CatalogBuild[];
   /** Vision projector (optional). When present, server boots with --mmproj. */
@@ -57,6 +66,15 @@ export interface CatalogFamily {
   name: string;
   series: string;
   description: string;
+  /**
+   * What this family is for. `'chat'` (default) = a generative chat/instruct
+   * model served on the main port. `'embedding'` = a dedicated embedding model
+   * served by `locca embed` with `--embeddings --pooling …` and *none* of the
+   * chat-only flags (no sampler, no `--jinja`). Chat-only pickers (serve, pi,
+   * setup, switch) filter embedding families out so they're never launched as
+   * a chat model by mistake.
+   */
+  kind?: 'chat' | 'embedding';
   /** Sampler/server defaults the family was tuned with. */
   serverArgs?: string[];
   /** weights · overheadMultiplier ≈ resident bytes. Default 1.05. */
@@ -73,6 +91,8 @@ export interface CatalogEntry {
   size: CatalogSize;
   build: CatalogBuild;
   hasVision: boolean;
+  /** `family.kind ?? 'chat'`, surfaced flat for easy filtering. */
+  kind: 'chat' | 'embedding';
 }
 
 const DEFAULT_OVERHEAD = 1.05;
@@ -318,6 +338,114 @@ export const catalog: CatalogFamily[] = [
       },
     ],
   },
+
+  // ── Embedding models ───────────────────────────────────────────────────
+  // Served by `locca embed` with `--embeddings --pooling <type>` on a separate
+  // port. These are tiny encoder models (no KV cache to speak of), so the
+  // ctxBytesPer1kTokens slope is nominal — they fit on anything. `pooling` is
+  // load-bearing: the wrong value silently returns wrong vectors.
+  {
+    name: 'Nomic Embed',
+    series: 'nomic',
+    kind: 'embedding',
+    description:
+      'Long-context English text embeddings (768-dim, Matryoshka-truncatable). Mean pooling; expects search_query:/search_document: task prefixes.',
+    overheadMultiplier: 1.2,
+    sizes: [
+      {
+        name: 'v1.5',
+        parameterCount: 137_000_000,
+        ctxWindow: 8192,
+        ctxBytesPer1kTokens: 4_194_304,
+        pooling: 'mean',
+        embedDim: 768,
+        builds: [
+          {
+            quantization: 'Q8_0',
+            fileSize: 146_146_432,
+            hfRepo: 'nomic-ai/nomic-embed-text-v1.5-GGUF',
+            hfFile: 'nomic-embed-text-v1.5.Q8_0.gguf',
+            isFullPrecision: true,
+          },
+          {
+            quantization: 'Q4_K_M',
+            fileSize: 84_106_624,
+            hfRepo: 'nomic-ai/nomic-embed-text-v1.5-GGUF',
+            hfFile: 'nomic-embed-text-v1.5.Q4_K_M.gguf',
+            isFullPrecision: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'mxbai Embed Large',
+    series: 'mxbai',
+    kind: 'embedding',
+    description:
+      "mixedbread.ai's high-quality English embeddings (1024-dim). CLS pooling; 512-token window.",
+    overheadMultiplier: 1.2,
+    sizes: [
+      {
+        name: 'v1',
+        parameterCount: 335_000_000,
+        ctxWindow: 512,
+        ctxBytesPer1kTokens: 8_388_608,
+        pooling: 'cls',
+        embedDim: 1024,
+        builds: [
+          {
+            quantization: 'Q8_0',
+            fileSize: 358_235_712,
+            hfRepo: 'ChristianAzinn/mxbai-embed-large-v1-gguf',
+            hfFile: 'mxbai-embed-large-v1.Q8_0.gguf',
+            isFullPrecision: true,
+          },
+          {
+            quantization: 'Q4_K_M',
+            fileSize: 215_891_488,
+            hfRepo: 'ChristianAzinn/mxbai-embed-large-v1-gguf',
+            hfFile: 'mxbai-embed-large-v1.Q4_K_M.gguf',
+            isFullPrecision: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'BGE-M3',
+    series: 'bge',
+    kind: 'embedding',
+    description:
+      'Multilingual (100+ languages), long-context (8192) dense embeddings (1024-dim) from BAAI. CLS pooling.',
+    overheadMultiplier: 1.2,
+    sizes: [
+      {
+        name: '567M',
+        parameterCount: 567_000_000,
+        ctxWindow: 8192,
+        ctxBytesPer1kTokens: 8_388_608,
+        pooling: 'cls',
+        embedDim: 1024,
+        builds: [
+          {
+            quantization: 'Q8_0',
+            fileSize: 634_553_760,
+            hfRepo: 'gpustack/bge-m3-GGUF',
+            hfFile: 'bge-m3-Q8_0.gguf',
+            isFullPrecision: true,
+          },
+          {
+            quantization: 'Q4_K_M',
+            fileSize: 437_778_496,
+            hfRepo: 'gpustack/bge-m3-GGUF',
+            hfFile: 'bge-m3-Q4_K_M.gguf',
+            isFullPrecision: false,
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 /**
@@ -339,13 +467,17 @@ function makeEntry(family: CatalogFamily, size: CatalogSize, build: CatalogBuild
     size,
     build,
     hasVision: Boolean(size.mmprojRepo && size.mmprojFile),
+    kind: family.kind ?? 'chat',
   };
 }
 
-export function allEntries(opts: { includeDeprecated?: boolean } = {}): CatalogEntry[] {
+export function allEntries(
+  opts: { includeDeprecated?: boolean; kind?: 'chat' | 'embedding' } = {},
+): CatalogEntry[] {
   const out: CatalogEntry[] = [];
   for (const family of catalog) {
     if (family.deprecated && !opts.includeDeprecated) continue;
+    if (opts.kind && (family.kind ?? 'chat') !== opts.kind) continue;
     for (const size of family.sizes) {
       for (const build of size.builds) {
         out.push(makeEntry(family, size, build));
@@ -405,8 +537,56 @@ export function serverArgsForModel(filename: string): string[] {
   const entry = findEntryByFilename(filename);
   if (!entry) return [];
   const out: string[] = ['--alias', entry.build.hfRepo];
-  if (entry.family.serverArgs?.length) out.push(...entry.family.serverArgs);
+  // Sampler defaults are chat-only — an embedding model has no sampling, so
+  // never inject them even if (somehow) one reaches a chat launch path.
+  if (entry.kind === 'chat' && entry.family.serverArgs?.length) out.push(...entry.family.serverArgs);
   return out;
+}
+
+export interface EmbeddingModelInfo {
+  /** HF repo to report as the model id via `--alias`, when known. */
+  alias?: string;
+  /** Pooling type to pass to `--pooling`. Defaults to `'mean'` for models we
+   *  don't recognise (the most common case and the documented workaround). */
+  pooling: 'mean' | 'cls' | 'last';
+  /** Expected output dimensionality, when known (informational). */
+  embedDim?: number;
+  /** Native context window, when known. */
+  ctxWindow?: number;
+}
+
+/**
+ * Resolve the launch metadata for an embedding model file. Catalog hit →
+ * the curated pooling/dim/alias. Miss → `{ pooling: 'mean' }`, matching the
+ * `--pooling mean` workaround in the issue and the most common pooling type.
+ */
+export function embeddingInfoForModel(filename: string): EmbeddingModelInfo {
+  const entry = findEntryByFilename(filename);
+  if (entry && entry.kind === 'embedding') {
+    return {
+      alias: entry.build.hfRepo,
+      pooling: entry.size.pooling ?? 'mean',
+      embedDim: entry.size.embedDim,
+      ctxWindow: entry.size.ctxWindow,
+    };
+  }
+  return { pooling: 'mean' };
+}
+
+/**
+ * Heuristic: is this model file an embedding model rather than a chat model?
+ * Catalog hit is authoritative (`kind === 'embedding'`); otherwise fall back
+ * to common embedding-model name fragments. Used to keep embedding models out
+ * of chat pickers and route them to `locca embed`.
+ */
+export function isEmbeddingModelName(name: string): boolean {
+  const entry =
+    findEntryByFilename(name.toLowerCase().endsWith('.gguf') ? name : `${name}.gguf`) ??
+    findEntryByFilename(name);
+  if (entry) return entry.kind === 'embedding';
+  return /(?:^|[-_.])(?:embed|embedding|bge|nomic-embed|mxbai|gte|e5|minilm|snowflake-arctic-embed|jina-embed)(?:[-_.]|$)/i.test(
+    name,
+  );
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,14 +7,15 @@ function printHelp(): void {
   console.log(`Usage: locca [command]
 
 Inference:
-  serve       Start API server with a model (detached)
-  pi [name]   Launch pi coding agent with a local model
-  switch      Stop current server and start a new model with pi
-  stop        Stop running server
-  bench       Benchmark a model
+  serve         Start API server with a model (detached)
+  embed [name]  Start a dedicated embedding server (separate port)
+  pi [name]     Launch pi coding agent with a local model
+  switch        Stop current server and start a new model with pi
+  stop          Stop running server(s)
+  bench         Benchmark a model
 
-  logs        Tail llama-server log (pi-started servers)
-  api         Print OpenAI-compatible connection info
+  logs [embed]  Tail llama-server log (chat by default, or embed)
+  api           Print OpenAI-compatible connection info
 
 Models:
   download    Download model from HuggingFace
@@ -61,6 +62,12 @@ async function dispatch(): Promise<void> {
       await m.serve();
       return;
     }
+    case 'embed':
+    case 'embeddings': {
+      const m = await import('./commands/embed.js');
+      await m.embed(rest);
+      return;
+    }
     case 'pi': {
       const m = await import('./commands/pi.js');
       await m.pi(rest);
@@ -80,7 +87,7 @@ async function dispatch(): Promise<void> {
     case 'logs':
     case 'log': {
       const m = await import('./commands/logs.js');
-      await m.logs();
+      await m.logs(rest);
       return;
     }
     case 'bench': {

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -1,12 +1,14 @@
+import { embeddingInfoForModel } from '../catalog.js';
 import { loadConfig } from '../config.js';
-import { serverStatus } from '../server.js';
+import { type ServerStatus, serverStatus } from '../server.js';
 import { pc } from '../ui.js';
 import { networkAddresses } from '../util.js';
 
-/** `locca api` — print OpenAI-compatible connection info for the local server. */
+/** `locca api` — print OpenAI-compatible connection info for the local server(s). */
 export async function api(): Promise<void> {
   const cfg = loadConfig();
-  const status = await serverStatus(cfg);
+  const status = await serverStatus(cfg, 'chat');
+  const embedStatus = await serverStatus(cfg, 'embed');
 
   let baseUrl: string;
   let port: number;
@@ -61,11 +63,20 @@ export async function api(): Promise<void> {
   console.log(`  API key     any non-empty string (e.g. "unused") — not validated`);
   console.log(`              unless server was started with --api-key`);
   console.log();
+
+  // Whether the *primary* server can actually embed. Probed, not assumed —
+  // the old code advertised /embeddings unconditionally, which lied for chat
+  // models. A chat server answers this probe with an immediate 500, so it's
+  // cheap. A dedicated embedding server is reported in its own block below.
+  const primaryEmbed = live ? await probeEmbeddings(baseUrl, modelName) : { ok: false };
+
   console.log(`  ${pc.magenta(pc.bold('Endpoints (OpenAI)'))}`);
   console.log(`    ${baseUrl}/chat/completions   chat (use this for agents)`);
   console.log(`    ${baseUrl}/completions        raw text completion`);
-  console.log(`    ${baseUrl}/embeddings         embeddings (if model supports)`);
   console.log(`    ${baseUrl}/models             list loaded models`);
+  console.log(
+    `    ${baseUrl}/embeddings         ${embeddingsHint(primaryEmbed, live)}`,
+  );
   console.log();
   const root = baseUrl.replace(/\/v1$/, '');
   console.log(`  ${pc.magenta(pc.bold('Native (debugging)'))}`);
@@ -81,6 +92,116 @@ export async function api(): Promise<void> {
     `      -d '{"model":"${modelName}","messages":[{"role":"user","content":"Hello!"}]}'`,
   );
   console.log();
+
+  // Dedicated embedding server block — only when one is actually up on the
+  // embed port and it isn't the same process we just described.
+  if (embedStatus.running && (!status.running || embedStatus.url !== status.url)) {
+    await printEmbeddingBlock(embedStatus);
+  }
+}
+
+/** Render the `/embeddings` endpoint hint based on a live probe. */
+function embeddingsHint(probe: { ok: boolean; dim?: number; pooling?: string }, live: boolean): string {
+  if (!live) return pc.dim('embeddings (probe when running)');
+  if (!probe.ok) return pc.dim('not supported by the loaded model — use `locca embed`');
+  const bits = [`${probe.dim}-dim`];
+  if (probe.pooling) bits.push(`pooling ${probe.pooling}`);
+  return pc.green(`✓ ${bits.join(', ')}`);
+}
+
+/** Print a full connection block for a dedicated embedding server. */
+async function printEmbeddingBlock(status: Extract<ServerStatus, { running: true }>): Promise<void> {
+  const baseUrl = `${status.url}/v1`;
+  const modelName = status.model ?? 'local';
+  const source =
+    status.source === 'pid' ? `locca (pid ${status.pid})` : 'attached (external process)';
+  const probe = await probeEmbeddings(baseUrl, modelName);
+
+  console.log(`  ${pc.magenta(pc.bold('Embedding server'))}`);
+  if (probe.ok) {
+    console.log(pc.green(`  ● Running — ${source}`));
+  } else {
+    // Health is up (serverStatus said running) but the embeddings probe
+    // failed — say so rather than implying it works.
+    console.log(pc.yellow(`  ● Running — ${source} (embeddings probe failed; check \`locca logs embed\`)`));
+  }
+  console.log();
+  console.log(`  Base URL    ${pc.cyan(baseUrl)}`);
+  console.log(`  Model name  ${pc.cyan(modelName)}`);
+  if (probe.ok) {
+    // Pooling: prefer the live /props value; fall back to the catalog value we
+    // launched the model with (many llama-server builds don't expose it in
+    // /props). Honest either way — it's the pooling actually in effect.
+    const pooling = probe.pooling ?? embeddingInfoForModel(modelName).pooling;
+    console.log(`  Vectors     ${probe.dim}-dim${pooling ? ` · pooling ${pooling}` : ''}`);
+  }
+  console.log();
+  console.log(`  ${pc.magenta(pc.bold('Quick test'))}`);
+  console.log(`    curl ${baseUrl}/embeddings \\`);
+  console.log(`      -H "Content-Type: application/json" \\`);
+  console.log(`      -d '{"model":"${modelName}","input":"hello world"}'`);
+  console.log();
+}
+
+/**
+ * POST a tiny input to `/embeddings` and read back the vector length, plus the
+ * pooling type from `/props`. This is the honest test: a server "supports
+ * embeddings" iff it returns a vector. Returns `{ ok: false }` on any failure
+ * (chat models 500 here immediately, so it's cheap).
+ */
+async function probeEmbeddings(
+  baseUrl: string,
+  model: string,
+): Promise<{ ok: boolean; dim?: number; pooling?: string }> {
+  try {
+    const r = await fetch(`${baseUrl.replace(/\/$/, '')}/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, input: 'locca embedding probe' }),
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!r.ok) return { ok: false };
+    const data = (await r.json()) as { data?: Array<{ embedding?: number[] }> };
+    const dim = data.data?.[0]?.embedding?.length;
+    if (typeof dim !== 'number' || dim === 0) return { ok: false };
+    const pooling = await probePooling(baseUrl);
+    return { ok: true, dim, pooling };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** Read the pooling type from `/props`, mapping llama.cpp's numeric enum to a
+ *  label. Returns undefined when the build doesn't expose it. */
+async function probePooling(baseUrl: string): Promise<string | undefined> {
+  try {
+    const root = baseUrl.replace(/\/v1$/, '');
+    const r = await fetch(`${root}/props`, { signal: AbortSignal.timeout(1500) });
+    if (!r.ok) return undefined;
+    const d = (await r.json()) as {
+      pooling_type?: number | string;
+      default_generation_settings?: { pooling_type?: number | string };
+    };
+    const pt = d.pooling_type ?? d.default_generation_settings?.pooling_type;
+    return poolingLabel(pt);
+  } catch {
+    return undefined;
+  }
+}
+
+// llama.cpp's llama_pooling_type enum.
+const POOLING_LABELS: Record<number, string> = {
+  0: 'none',
+  1: 'mean',
+  2: 'cls',
+  3: 'last',
+  4: 'rank',
+};
+
+function poolingLabel(pt: number | string | undefined): string | undefined {
+  if (pt === undefined) return undefined;
+  if (typeof pt === 'string') return pt;
+  return POOLING_LABELS[pt];
 }
 
 async function probeReachableUrls(port: number): Promise<{ lan: string[]; tailscale: string[] }> {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -43,6 +43,19 @@ const SCHEMA: Field[] = [
   },
   { key: 'defaultPort', label: 'Default server port', kind: 'number' },
   {
+    key: 'defaultEmbedPort',
+    label: 'Embedding server port',
+    kind: 'number',
+    hint: 'port for `locca embed`; must differ from defaultPort',
+  },
+  {
+    key: 'defaultEmbedModel',
+    label: 'Embedding sidecar model',
+    kind: 'string',
+    optional: true,
+    hint: 'filename/substring to auto-start alongside `locca serve`; empty = none',
+  },
+  {
     key: 'defaultCtx',
     label: 'Default context size',
     kind: 'number',

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,0 +1,184 @@
+import { basename } from 'node:path';
+import * as p from '@clack/prompts';
+import { embeddingInfoForModel, isEmbeddingModelName } from '../catalog.js';
+import { loadConfig } from '../config.js';
+import { requireLlama } from '../deps.js';
+import { findFirstMatch, pickModel, scanModels } from '../models.js';
+import { refuseIfPortTaken } from '../preflight.js';
+import {
+  isPortInUse,
+  launchServer,
+  portForRole,
+  serverStatus,
+  stopServer,
+  waitReady,
+} from '../server.js';
+import type { Config, Model } from '../types.js';
+import { exitIfCancelled, pc } from '../ui.js';
+import { api } from './api.js';
+
+// Embedding encoders have small native windows; cap the ctx (and therefore the
+// per-request ubatch buffer) so we don't over-allocate. 8192 covers nomic and
+// bge-m3; mxbai's 512 is honoured as-is.
+const EMBED_CTX_CAP = 8192;
+
+/**
+ * `locca embed [model]` — start a dedicated embedding server on the embed port
+ * (default 8090), independent of the chat server. Picks an embedding model
+ * (filtered from `modelsDir`), launches llama-server with `--embeddings
+ * --pooling <type>`, and prints the OpenAI-compatible connection info.
+ */
+export async function embed(args: string[]): Promise<void> {
+  const cfg = loadConfig();
+  const port = portForRole(cfg, 'embed');
+
+  // First positional may be a model name pattern (mirrors `locca pi <pattern>`).
+  const pattern = args[0] && !args[0].startsWith('-') ? args[0] : undefined;
+
+  // Resolve who's on the embed port before requiring llama-server.
+  const status = await serverStatus(cfg, 'embed');
+  if (status.running) {
+    if (status.source === 'attached') {
+      p.log.error(
+        `Something is already responding on embed port ${status.port} (${status.url}) — locca did not start it. Stop it via whatever started it before running \`locca embed\`.`,
+      );
+      process.exit(1);
+    }
+    p.log.info(`Stopping current embedding server (pid ${status.pid}) to start a new one...`);
+    await stopServer(cfg, 'embed');
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  if (port === cfg.defaultPort) {
+    p.log.error(
+      `defaultEmbedPort (${port}) is the same as defaultPort — the embedding server can't share the chat server's port. Set a different defaultEmbedPort with \`locca config set defaultEmbedPort <port>\`.`,
+    );
+    process.exit(1);
+  }
+
+  requireLlama(cfg);
+
+  const models = scanModels(cfg.modelsDir);
+  if (models.length === 0) {
+    p.log.error(`No models found in ${cfg.modelsDir}`);
+    process.exit(1);
+  }
+
+  // Prefer embedding-classified models; if none are recognised, fall back to
+  // the full list so a user who knows their model is an embedder can still
+  // pick it (we warn after selection if it doesn't look like one).
+  const embedModels = models.filter((m) => isEmbeddingModelName(m.name));
+  const pool = embedModels.length > 0 ? embedModels : models;
+  if (embedModels.length === 0) {
+    p.log.warn(
+      "No embedding models detected in your models dir. Download one with `locca download nomic-ai/nomic-embed-text-v1.5-GGUF` (or mxbai / bge-m3), or pick below if you know it's an embedder.",
+    );
+  }
+
+  const model = pattern
+    ? findFirstMatch(pool, pattern)
+    : await pickModel(pool, 'Pick an embedding model');
+  if (!model) {
+    if (pattern) p.log.error(`No model matching '${pattern}'`);
+    return;
+  }
+
+  await refuseIfPortTaken(port);
+
+  const ctx = launchEmbed(cfg, model, port);
+
+  printStartupBanner(model, port, ctx);
+
+  const ready = await waitReady(port, 60);
+  if (!ready) {
+    p.log.warn(
+      'Embedding server did not become ready within 60s — run `locca logs embed` to see output.',
+    );
+    return;
+  }
+
+  await api();
+  console.log(`  ${pc.dim('Stop with: locca stop  |  Logs: locca logs embed')}`);
+  console.log();
+}
+
+/**
+ * Launch the embedding server (detached) for `model` on `port`. Shared by the
+ * `embed` command and the `serve` sidecar. Returns the ctx it used.
+ */
+export function launchEmbed(cfg: Config, model: Model, port: number): number {
+  const info = embeddingInfoForModel(basename(model.path));
+  const ctx = Math.min(info.ctxWindow ?? EMBED_CTX_CAP, EMBED_CTX_CAP);
+  launchServer({
+    llamaServer: cfg.llamaServer,
+    modelPath: model.path,
+    port,
+    ctx,
+    threads: cfg.defaultThreads,
+    mode: 'embedding',
+    pooling: info.pooling,
+    role: 'embed',
+    extraArgs: info.alias ? ['--alias', info.alias] : [],
+    noMmap: cfg.noMmap,
+    detached: true,
+  });
+  return ctx;
+}
+
+/**
+ * Best-effort embedding sidecar for `locca serve`. No-ops when
+ * `cfg.defaultEmbedModel` is unset. Never throws — a failed sidecar must not
+ * take down the chat server the user actually asked for. Returns a short
+ * status line for the caller to print, or null when nothing was attempted.
+ */
+export async function startEmbeddingSidecar(cfg: Config): Promise<string | null> {
+  if (!cfg.defaultEmbedModel) return null;
+  const port = portForRole(cfg, 'embed');
+  if (port === cfg.defaultPort) {
+    return pc.yellow(`Embedding sidecar skipped: defaultEmbedPort (${port}) clashes with defaultPort.`);
+  }
+
+  const status = await serverStatus(cfg, 'embed');
+  if (status.running) {
+    return pc.dim(`Embedding server already running on :${status.port}.`);
+  }
+  if (await refuseIfPortTakenQuiet(port)) {
+    return pc.yellow(`Embedding sidecar skipped: port ${port} is occupied by something else.`);
+  }
+
+  const models = scanModels(cfg.modelsDir);
+  const model = findFirstMatch(models, cfg.defaultEmbedModel);
+  if (!model) {
+    return pc.yellow(
+      `Embedding sidecar skipped: no model matching defaultEmbedModel='${cfg.defaultEmbedModel}'.`,
+    );
+  }
+
+  const ctx = launchEmbed(cfg, model, port);
+  const ready = await waitReady(port, 60);
+  if (!ready) {
+    return pc.yellow(
+      `Embedding sidecar (${model.name}) did not become ready in 60s — see \`locca logs embed\`.`,
+    );
+  }
+  return pc.green(`Embedding server up: ${model.name} on :${port} (ctx ${ctx}).`);
+}
+
+/** Like `refuseIfPortTaken` but returns a boolean instead of exiting — the
+ *  sidecar must degrade gracefully, not kill the parent `serve`. */
+async function refuseIfPortTakenQuiet(port: number): Promise<boolean> {
+  return isPortInUse(port);
+}
+
+function printStartupBanner(model: Model, port: number, ctx: number): void {
+  const info = embeddingInfoForModel(basename(model.path));
+  console.log();
+  console.log(pc.magenta(pc.bold('  Starting embedding server...')));
+  console.log(`  Model:   ${model.name}`);
+  console.log(`  Port:    ${port}`);
+  console.log(`  Context: ${ctx}`);
+  console.log(`  Pooling: ${info.pooling}`);
+  if (info.embedDim) console.log(`  Vectors: ${info.embedDim}-dim`);
+  console.log(`  GPU:     Vulkan (all layers)`);
+  console.log();
+}

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,18 +1,26 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
-import { LOGFILE } from '../server.js';
+import { logFile } from '../server.js';
 import { note, pc } from '../ui.js';
 
 const TAIL_LINES = 100;
 
-export async function logs(): Promise<void> {
-  if (!existsSync(LOGFILE) || statSync(LOGFILE).size === 0) {
-    note(`No log at ${LOGFILE} (only servers started via 'locca pi' write here).`);
+export async function logs(args: string[] = []): Promise<void> {
+  // `locca logs embed` tails the embedding server's log; default is the chat
+  // server's log.
+  const role = args[0] === 'embed' ? 'embed' : 'chat';
+  const target = logFile(role);
+  const label = role === 'embed' ? 'embedding ' : '';
+
+  if (!existsSync(target) || statSync(target).size === 0) {
+    note(
+      `No ${label}log at ${target} (only detached locca-started servers write here).`,
+    );
     return;
   }
-  console.log(pc.magenta(`Last ${TAIL_LINES} lines of ${LOGFILE}`));
+  console.log(pc.magenta(`Last ${TAIL_LINES} lines of ${target}`));
   console.log();
-  spawnSync('tail', ['-n', String(TAIL_LINES), LOGFILE], { stdio: 'inherit' });
+  spawnSync('tail', ['-n', String(TAIL_LINES), target], { stdio: 'inherit' });
   console.log();
-  note(`Run \`tail -f ${LOGFILE}\` in a separate terminal to follow live.`);
+  note(`Run \`tail -f ${target}\` in a separate terminal to follow live.`);
 }

--- a/src/commands/pi.ts
+++ b/src/commands/pi.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { basename } from 'node:path';
 import * as p from '@clack/prompts';
-import { mtpArgsForModel, serverArgsForModel } from '../catalog.js';
+import { isEmbeddingModelName, mtpArgsForModel, serverArgsForModel } from '../catalog.js';
 import { loadConfig } from '../config.js';
 import { requireLlama, requirePi } from '../deps.js';
 import { ctxForModel, findFirstMatch, pickModel, scanModels } from '../models.js';
@@ -31,15 +31,26 @@ export async function pi(args: string[], opts: PiOpts = {}): Promise<void> {
   // ── Local mode: we manage llama-server ──────────────────────────────
   requireLlama(cfg);
 
-  const models = scanModels(cfg.modelsDir);
-  if (models.length === 0) {
+  const allModels = scanModels(cfg.modelsDir);
+  if (allModels.length === 0) {
     p.log.error(`No models found in ${cfg.modelsDir}`);
     process.exit(1);
   }
 
+  // pi drives a chat model; embedding models can't fill that role. Keep them
+  // out of the picker (a positional pattern still searches the full list so an
+  // explicit, deliberate match isn't silently dropped).
+  const chatModels = allModels.filter((m) => !isEmbeddingModelName(m.name));
+  if (!pattern && chatModels.length === 0) {
+    p.log.error(
+      `Only embedding models found in ${cfg.modelsDir}. pi needs a chat model — download one with \`locca download\`.`,
+    );
+    process.exit(1);
+  }
+
   const model = pattern
-    ? findFirstMatch(models, pattern)
-    : await pickModel(models, 'Pick a model for pi');
+    ? findFirstMatch(allModels, pattern)
+    : await pickModel(chatModels, 'Pick a model for pi');
 
   if (!model) {
     if (pattern) p.log.error(`No model matching '${pattern}'`);

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path';
 import * as p from '@clack/prompts';
-import { mtpArgsForModel, serverArgsForModel } from '../catalog.js';
+import { isEmbeddingModelName, mtpArgsForModel, serverArgsForModel } from '../catalog.js';
 import { loadConfig } from '../config.js';
 import { requireLlama } from '../deps.js';
 import { pickModel, scanModels } from '../models.js';
@@ -9,6 +9,7 @@ import { launchServer, serverStatus, stopServer, waitReady } from '../server.js'
 import type { Model } from '../types.js';
 import { exitIfCancelled, pc } from '../ui.js';
 import { api } from './api.js';
+import { startEmbeddingSidecar } from './embed.js';
 
 export async function serve(): Promise<void> {
   const cfg = loadConfig();
@@ -37,7 +38,17 @@ export async function serve(): Promise<void> {
     process.exit(1);
   }
 
-  const model = await pickModel(models, 'Pick a model to serve');
+  // Embedding models can't serve chat (they'd hit the "Pooling type 'none'"
+  // wall). Keep them out of the chat picker and point users at `locca embed`.
+  const chatModels = models.filter((m) => !isEmbeddingModelName(m.name));
+  if (chatModels.length === 0) {
+    p.log.error(
+      `Only embedding models found in ${cfg.modelsDir}. Serve those with \`locca embed\`, or download a chat model with \`locca download\`.`,
+    );
+    process.exit(1);
+  }
+
+  const model = await pickModel(chatModels, 'Pick a model to serve');
   if (!model) return;
 
   const choice = await p.select({
@@ -105,6 +116,14 @@ export async function serve(): Promise<void> {
   if (!ready) {
     p.log.warn('Server did not become ready within 60s — run `locca logs` to see output.');
     return;
+  }
+
+  // Bring up the embedding sidecar if one is configured. Best-effort: a
+  // failure here is reported but never blocks the chat server.
+  const sidecar = await startEmbeddingSidecar(cfg);
+  if (sidecar) {
+    console.log(`  ${sidecar}`);
+    console.log();
   }
 
   // Show the OpenAI-compatible connection info — same output as

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -4,10 +4,30 @@ import { stopServer } from '../server.js';
 
 export async function stop(): Promise<void> {
   const cfg = loadConfig();
-  const r = await stopServer(cfg);
-  if (r.stopped) {
-    p.log.success(`Server stopped (pid ${r.pid})`);
-  } else {
-    p.log.message(r.reason);
+
+  // Stop both the chat server and the embedding sidecar (if either is
+  // locca-managed). Each stop is independent — one being absent or attached
+  // doesn't affect the other.
+  const chat = await stopServer(cfg, 'chat');
+  const embed = await stopServer(cfg, 'embed');
+
+  let stopped = false;
+  if (chat.stopped) {
+    p.log.success(`Chat server stopped (pid ${chat.pid})`);
+    stopped = true;
+  }
+  if (embed.stopped) {
+    p.log.success(`Embedding server stopped (pid ${embed.pid})`);
+    stopped = true;
+  }
+
+  if (!stopped) {
+    // Neither was locca-managed. Surface the chat reason; mention the embed
+    // one too when it differs (e.g. an attached embedding server).
+    const chatReason = chat.stopped ? 'no server running' : chat.reason;
+    p.log.message(chatReason);
+    if (!embed.stopped && embed.reason !== chatReason && embed.reason !== 'no server running') {
+      p.log.message(`embedding: ${embed.reason}`);
+    }
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ function defaults(): Config {
     piSkills: 'lazy',
     piExtensions: true,
     defaultParallel: 1,
+    defaultEmbedPort: 8090,
     noMmap: false,
     mtp: 'auto',
   };

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -14,6 +14,7 @@ import { config } from './commands/config.js';
 import { del } from './commands/delete.js';
 import { doctor } from './commands/doctor.js';
 import { download, downloadCatalogEntry } from './commands/download.js';
+import { embed } from './commands/embed.js';
 import { logs } from './commands/logs.js';
 import { optimise } from './commands/optimise.js';
 import { pi } from './commands/pi.js';
@@ -30,6 +31,7 @@ import { formatGB, have } from './util.js';
 type Action =
   | 'pi'
   | 'serve'
+  | 'embed'
   | 'switch'
   | 'download'
   | 'search'
@@ -54,16 +56,19 @@ export async function menu(): Promise<void> {
     // "back to menu" loop doesn't keep redrawing two screens of art.
     printBanner({ tagline: firstRender });
     firstRender = false;
-    const serverRunning = await renderServerLine();
+    const running = await renderServerLine();
     renderSetupAlerts();
     console.log();
 
     const options: { value: Action; label: string }[] = [
       { value: 'pi', label: 'Pi       — coding agent (local)' },
       { value: 'serve', label: 'Serve    — start API server' },
+      { value: 'embed', label: 'Embed    — start embedding server (separate port)' },
     ];
-    if (serverRunning) {
-      options.push({ value: 'stop', label: 'Stop     — stop server' });
+    if (running.chat || running.embed) {
+      options.push({ value: 'stop', label: 'Stop     — stop server(s)' });
+    }
+    if (running.chat) {
       options.push({
         value: 'switch',
         label: 'Switch   — swap server to a different model',
@@ -132,26 +137,34 @@ async function pauseUntilEnter(): Promise<void> {
  * for ctx + slot count — best-effort, missing fields are simply elided so a
  * llama-server build that doesn't expose them still renders cleanly.
  */
-async function renderServerLine(): Promise<boolean> {
+async function renderServerLine(): Promise<{ chat: boolean; embed: boolean }> {
   const cfg = loadConfig();
-  const s = await serverStatus(cfg);
-  if (!s.running) {
-    p.note(pc.dim('○ No server running'), 'Server');
-    return false;
-  }
-  const sourceLabel = s.source === 'pid' ? `running (pid ${s.pid})` : 'attached';
-  const lines: string[] = [];
-  lines.push(`${pc.green('●')} ${pc.bold(sourceLabel)} on :${s.port}`);
-  if (s.model) lines.push(pc.dim(s.model));
+  const [s, e] = await Promise.all([serverStatus(cfg, 'chat'), serverStatus(cfg, 'embed')]);
 
-  const props = await probeServerProps(s.url);
-  const subBits: string[] = [];
-  if (props.ctx) subBits.push(`ctx ${props.ctx.toLocaleString('en-US')}`);
-  if (props.slots) subBits.push(`${props.slots} slot${props.slots === 1 ? '' : 's'}`);
-  if (subBits.length) lines.push(pc.dim(subBits.join(' · ')));
+  if (!s.running && !e.running) {
+    p.note(pc.dim('○ No server running'), 'Server');
+    return { chat: false, embed: false };
+  }
+
+  const lines: string[] = [];
+  if (s.running) {
+    const sourceLabel = s.source === 'pid' ? `running (pid ${s.pid})` : 'attached';
+    lines.push(`${pc.green('●')} chat — ${pc.bold(sourceLabel)} on :${s.port}`);
+    if (s.model) lines.push(pc.dim(`  ${s.model}`));
+    const props = await probeServerProps(s.url);
+    const subBits: string[] = [];
+    if (props.ctx) subBits.push(`ctx ${props.ctx.toLocaleString('en-US')}`);
+    if (props.slots) subBits.push(`${props.slots} slot${props.slots === 1 ? '' : 's'}`);
+    if (subBits.length) lines.push(pc.dim(`  ${subBits.join(' · ')}`));
+  }
+  if (e.running) {
+    const sourceLabel = e.source === 'pid' ? `running (pid ${e.pid})` : 'attached';
+    lines.push(`${pc.green('●')} embed — ${pc.bold(sourceLabel)} on :${e.port}`);
+    if (e.model) lines.push(pc.dim(`  ${e.model}`));
+  }
 
   p.note(lines.join('\n'), 'llama-server');
-  return true;
+  return { chat: s.running, embed: e.running };
 }
 
 /**
@@ -196,6 +209,9 @@ async function runAction(action: Exclude<Action, 'quit'>): Promise<void> {
       break;
     case 'serve':
       await serve();
+      break;
+    case 'embed':
+      await embed([]);
       break;
     case 'switch':
       await switchModel();
@@ -464,7 +480,8 @@ interface CatalogRow {
 
 function catalogRows(budget: ReturnType<typeof memoryBudget>): CatalogRow[] {
   const buckets = new Map<string, CatalogEntry[]>();
-  for (const e of allEntries()) {
+  // Chat only — switching the chat server to an embedding model makes no sense.
+  for (const e of allEntries({ kind: 'chat' })) {
     const k = `${e.family.name}|${e.size.name}`;
     const list = buckets.get(k);
     if (list) list.push(e);

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,8 +5,30 @@ import { join } from 'node:path';
 import type { Config } from './types.js';
 
 const RUNDIR = process.env.XDG_RUNTIME_DIR ?? '/tmp';
-export const PIDFILE = join(RUNDIR, 'locca-server.pid');
-export const LOGFILE = join(RUNDIR, 'locca-server.log');
+
+/**
+ * locca can run two servers side by side: the chat/generative server (`serve`,
+ * `pi`) and a dedicated embedding server (`embed`). Each gets its own PIDFILE,
+ * logfile, and port so their lifecycles are independent.
+ */
+export type ServerRole = 'chat' | 'embed';
+
+export function pidFile(role: ServerRole = 'chat'): string {
+  return join(RUNDIR, role === 'embed' ? 'locca-embed.pid' : 'locca-server.pid');
+}
+export function logFile(role: ServerRole = 'chat'): string {
+  return join(RUNDIR, role === 'embed' ? 'locca-embed.log' : 'locca-server.log');
+}
+
+/** Default port for a role: chat → `defaultPort`, embed → `defaultEmbedPort`. */
+export function portForRole(cfg: Config, role: ServerRole = 'chat'): number {
+  return role === 'embed' ? (cfg.defaultEmbedPort ?? 8090) : cfg.defaultPort;
+}
+
+// Back-compat aliases for the chat server's runtime files. Existing imports
+// (`logs`, `pi`, docs) reference these directly.
+export const PIDFILE = pidFile('chat');
+export const LOGFILE = logFile('chat');
 
 export function isAlive(pid: number): boolean {
   try {
@@ -158,16 +180,21 @@ export async function probeServer(
 }
 
 /**
- * Resolve current server status, in priority order:
- *   1. PIDFILE exists + alive  → use that (source: 'pid').
- *   2. Local default port responds → use it (source: 'attached').
+ * Resolve current server status for a role, in priority order:
+ *   1. role PIDFILE exists + alive  → use that (source: 'pid').
+ *   2. Local role port responds     → use it (source: 'attached').
  *   3. Otherwise nothing.
+ *
+ * `role` defaults to `'chat'` so every existing caller is unchanged. Pass
+ * `'embed'` to inspect the embedding sidecar (its own PIDFILE + port).
  */
-export async function serverStatus(cfg: Config): Promise<ServerStatus> {
-  if (existsSync(PIDFILE)) {
+export async function serverStatus(cfg: Config, role: ServerRole = 'chat'): Promise<ServerStatus> {
+  const pf = pidFile(role);
+  const rolePort = portForRole(cfg, role);
+  if (existsSync(pf)) {
     let pid = NaN;
     try {
-      pid = parseInt(readFileSync(PIDFILE, 'utf8').trim(), 10);
+      pid = parseInt(readFileSync(pf, 'utf8').trim(), 10);
     } catch {
       // fall through to cleanup
     }
@@ -175,7 +202,7 @@ export async function serverStatus(cfg: Config): Promise<ServerStatus> {
       const args = readArgs(pid);
       const portMatch = args.match(/--port\s+(\d+)/);
       const modelMatch = args.match(/--model\s+(\S+\.gguf)/);
-      const port = portMatch ? parseInt(portMatch[1]!, 10) : cfg.defaultPort;
+      const port = portMatch ? parseInt(portMatch[1]!, 10) : rolePort;
       return {
         running: true,
         source: 'pid',
@@ -186,22 +213,22 @@ export async function serverStatus(cfg: Config): Promise<ServerStatus> {
       };
     }
     try {
-      unlinkSync(PIDFILE);
+      unlinkSync(pf);
     } catch {
       // ignore
     }
   }
 
-  // Maybe something's already on our default port (a llama-server started
+  // Maybe something's already on the role's port (a llama-server started
   // outside locca — by hand, by a supervisor, by another tool).
-  const localUrl = `http://127.0.0.1:${cfg.defaultPort}`;
+  const localUrl = `http://127.0.0.1:${rolePort}`;
   const probe = await probeServer(localUrl, 600);
   if (probe.alive) {
     return {
       running: true,
       source: 'attached',
       url: localUrl,
-      port: cfg.defaultPort,
+      port: rolePort,
       model: probe.model,
     };
   }
@@ -227,8 +254,8 @@ export type StopResult = { stopped: true; pid: number } | { stopped: false; reas
  * Stop the server locca started. Refuses to touch attached servers —
  * those need to be stopped via the tool that started them.
  */
-export async function stopServer(cfg: Config): Promise<StopResult> {
-  const s = await serverStatus(cfg);
+export async function stopServer(cfg: Config, role: ServerRole = 'chat'): Promise<StopResult> {
+  const s = await serverStatus(cfg, role);
   if (!s.running) return { stopped: false, reason: 'no server running' };
   if (s.source === 'attached') {
     return {
@@ -244,7 +271,7 @@ export async function stopServer(cfg: Config): Promise<StopResult> {
     }
   }
   try {
-    unlinkSync(PIDFILE);
+    unlinkSync(pidFile(role));
   } catch {
     // ignore
   }
@@ -276,9 +303,22 @@ export interface ServeOpts {
   /**
    * Concurrent server slots (`--parallel`). Defaults to 1 when omitted.
    * Usually filled from `cfg.defaultParallel`. llama-server splits
-   * `--ctx-size` evenly across slots.
+   * `--ctx-size` evenly across slots. Ignored in embedding mode.
    */
   parallel?: number;
+  /**
+   * `'chat'` (default) bakes in the generative flags (`COMMON_ARGS`:
+   * `--jinja`, flash-attn, quantized KV cache, `--parallel`). `'embedding'`
+   * swaps in `--embeddings --pooling … --ubatch-size <ctx>` and drops every
+   * chat-only flag — that combination is what avoids llama.cpp's
+   * "Pooling type 'none' is not OAI compatible" / "does not support embeddings"
+   * walls.
+   */
+  mode?: 'chat' | 'embedding';
+  /** Pooling type for embedding mode (`--pooling`). Defaults to `'mean'`. */
+  pooling?: 'mean' | 'cls' | 'last';
+  /** Which runtime files (PIDFILE/logfile) to write. Defaults to `'chat'`. */
+  role?: ServerRole;
 }
 
 const COMMON_ARGS = [
@@ -297,7 +337,10 @@ const COMMON_ARGS = [
   '--jinja',
 ];
 
+const EMBED_ARGS = ['--n-gpu-layers', '999', '--embeddings'];
+
 export function buildServerArgs(opts: ServeOpts): string[] {
+  if (opts.mode === 'embedding') return buildEmbedArgs(opts);
   // Slot count: honour opts.parallel, but guard against bad/zero values.
   const parallel =
     Number.isInteger(opts.parallel) && (opts.parallel as number) > 0 ? (opts.parallel as number) : 1;
@@ -324,21 +367,59 @@ export function buildServerArgs(opts: ServeOpts): string[] {
   return args;
 }
 
+/**
+ * Argv for an embedding server. Deliberately *not* `COMMON_ARGS` + tweaks:
+ *   - `--embeddings --pooling <type>` is what makes `/v1/embeddings` work and
+ *     sidesteps the "Pooling type 'none'" error you get bolting `--embeddings`
+ *     onto a chat launch.
+ *   - `--ubatch-size == --batch-size == ctx`: non-causal encoder models must
+ *     process the whole sequence in one micro-batch, so the ubatch has to be
+ *     at least as large as the longest input.
+ *   - No `--jinja`, no flash-attn, no quantized KV cache, no `--parallel`,
+ *     no `--mmproj`, no sampler/MTP `extraArgs` — none apply to an encoder.
+ */
+function buildEmbedArgs(opts: ServeOpts): string[] {
+  const args = [
+    '--model',
+    opts.modelPath,
+    '--host',
+    opts.host ?? '0.0.0.0',
+    '--port',
+    String(opts.port),
+    '--threads',
+    String(opts.threads),
+    ...EMBED_ARGS,
+    '--pooling',
+    opts.pooling ?? 'mean',
+    '--ctx-size',
+    String(opts.ctx),
+    '--ubatch-size',
+    String(opts.ctx),
+    '--batch-size',
+    String(opts.ctx),
+  ];
+  if (opts.noMmap) args.push('--no-mmap');
+  if (opts.extraArgs?.length) args.push(...opts.extraArgs);
+  return args;
+}
+
 /** Launch llama-server. Returns the child process; caller decides how to wait. */
 export function launchServer(opts: ServeOpts): ChildProcess {
   const args = buildServerArgs(opts);
+  const role = opts.role ?? 'chat';
+  const pf = pidFile(role);
   if (opts.detached) {
-    const fd = openSync(LOGFILE, 'a');
+    const fd = openSync(logFile(role), 'a');
     const child = spawn(opts.llamaServer, args, {
       detached: true,
       stdio: ['ignore', fd, fd],
     });
     child.unref();
-    if (child.pid) writeFileSync(PIDFILE, `${child.pid}\n`);
+    if (child.pid) writeFileSync(pf, `${child.pid}\n`);
     return child;
   }
   const child = spawn(opts.llamaServer, args, { stdio: 'inherit' });
-  if (child.pid) writeFileSync(PIDFILE, `${child.pid}\n`);
+  if (child.pid) writeFileSync(pf, `${child.pid}\n`);
   return child;
 }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -330,7 +330,9 @@ interface FirstRunRow {
  * rows stay visible so users learn what their RAM can reach.
  */
 function pickBuildsForFirstRunMenu(budget: ReturnType<typeof memoryBudget>): FirstRunRow[] {
-  const entries = allEntries();
+  // Chat only — a first-time user needs something they can actually chat with;
+  // embedding models are downloaded later via `locca download` / `locca embed`.
+  const entries = allEntries({ kind: 'chat' });
   // Group by (family.name, size.name) so we render one row per size.
   const buckets = new Map<string, CatalogEntry[]>();
   for (const e of entries) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,21 @@ export interface Config {
    */
   defaultParallel?: number;
   /**
+   * Port for the dedicated embedding sidecar (`locca embed`). Default `8090`.
+   * Kept distinct from `defaultPort` on purpose — embeddings and chat are two
+   * separate llama-server processes that run side by side, so they can't share
+   * a port. Change it if 8090 is taken.
+   */
+  defaultEmbedPort?: number;
+  /**
+   * Embedding model to bring up as a sidecar alongside the chat server.
+   * A filename or substring matched against `modelsDir` (same rules as the
+   * `locca pi <pattern>` positional). When set, `locca serve` also launches
+   * the embedding server on `defaultEmbedPort`, and `locca stop` stops both.
+   * Unset (default) means no sidecar — run `locca embed` by hand when needed.
+   */
+  defaultEmbedModel?: string;
+  /**
    * Pass `--no-mmap` to llama-server. Default `false` — mmap is faster and
    * lower-memory on dedicated-VRAM GPUs and Apple Silicon. Set `true` only
    * on Strix Halo / Ryzen AI MAX+ where independent measurements report


### PR DESCRIPTION
Closes #7.

Adds a first-class path for serving a **dedicated embedding model alongside** the chat server, removing the sharp edge every embedding consumer otherwise hits (`This server does not support embeddings` / `Pooling type 'none' is not OAI compatible`).

## What's in it

**Catalog** — `kind: 'embedding'` families, all HF-verified (repo + exact file size):
- `nomic-embed-text-v1.5` (768-dim, mean pooling)
- `mxbai-embed-large-v1` (1024-dim, cls pooling)
- `bge-m3` (1024-dim, cls pooling, multilingual)

Pooling is stored per-model and is load-bearing — the wrong value silently returns wrong vectors. `locca search`/`download` resolve these repos and recommend the right build.

**`locca embed [model]`** — launches `llama-server` with `--embeddings --pooling <type> --ubatch-size <ctx>` and **none** of the chat-only flags (no `--jinja`, flash-attn, quantized KV cache, `--parallel`, sampler/MTP injection). Gets its own PIDFILE, logfile, and port (`defaultEmbedPort`, default **8090**) so it runs side by side with the chat server.

**Sidecar** — when `defaultEmbedModel` is set, `locca serve` brings the embedding server up as a best-effort sidecar (failure never blocks the chat server); `locca stop` stops both.

**Honest `locca api`** — probes `/v1/embeddings` for the real vector dim and reports pooling (live `/props`, catalog fallback when the build doesn't expose it) instead of advertising `/embeddings` unconditionally. A dedicated "Embedding server" block appears when one is up.

**Guardrails** — chat pickers (`serve`/`pi`/`setup`/`switch`) filter embedding models out and point users at `locca embed`; `locca logs embed` tails the embed log; two new keys (`defaultEmbedPort`, `defaultEmbedModel`) in the `config` schema.

## Architecture notes
- Server lifecycle is now role-aware (`'chat'` | `'embed'`): `pidFile(role)`, `logFile(role)`, `portForRole`, and `serverStatus`/`stopServer`/`launchServer` take an optional role that **defaults to `'chat'`** — every existing caller is unchanged.
- `buildServerArgs` branches on `mode: 'embedding'`; chat argv is byte-for-byte identical to before.

## Verification
- `npm run build` (strict tsc) — clean.
- Real end-to-end on a Strix Halo box: `locca embed nomic` launched on :8090, `/v1/embeddings` returned a real 768-dim vector, `locca api` reported `768-dim · pooling mean`, `locca logs embed` tailed the log, `locca stop` tore down the sidecar and cleaned up pidfiles.
- Embedding argv confirmed to drop all chat-only flags; chat argv unchanged.