### PR TITLE
feat(serve): head-less serve + official Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.claude
+.vscode
+.zed
+test
+docs
+*.log
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+#
+# locca in a container — runs llama.cpp's OpenAI-compatible server head-less.
+#
+# Point any OpenAI-compatible client (SUB/WAVE: provider = openai-compatible)
+# at http://<host>:8080/v1. See README "Running in Docker".
+#
+#   docker build -t locca .                       # CPU build (works anywhere)
+#   docker build -t locca:vulkan \                # AMD/Intel GPU via Vulkan
+#       --build-arg LLAMA_BACKEND=vulkan .
+#
+#   docker run --rm -p 8080:8080 \
+#       -v /path/to/models:/models:ro \
+#       locca qwen3.5-9b           # model name (substring match) or -e LOCCA_MODEL
+
+# ── Stage 1: build locca from source ────────────────────────────────────
+FROM node:22-bookworm AS build
+WORKDIR /src
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+COPY bin ./bin
+RUN npm run build && npm prune --omit=dev
+
+# ── Stage 2: runtime ────────────────────────────────────────────────────
+FROM node:22-bookworm-slim AS runtime
+
+# Backend for the bundled llama.cpp:
+#   cpu    — portable, runs on any host (default)
+#   vulkan — AMD / Intel GPU; needs `--device /dev/dri` at run time and the
+#            mesa ICD installed below
+ARG LLAMA_BACKEND=cpu
+
+# unzip       — llama.cpp release assets are .zip
+# ca-certs    — TLS to GitHub for `install-llama`
+# libgomp1    — OpenMP runtime the prebuilt llama-server links against
+# libcurl4    — recent llama-server builds link libcurl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates unzip libgomp1 libcurl4 \
+ && if [ "$LLAMA_BACKEND" = "vulkan" ]; then \
+      apt-get install -y --no-install-recommends libvulkan1 mesa-vulkan-drivers; \
+    fi \
+ && rm -rf /var/lib/apt/lists/*
+
+# locca itself (built in stage 1).
+COPY --from=build /src /opt/locca
+RUN ln -s /opt/locca/bin/locca /usr/local/bin/locca
+
+# Download the prebuilt llama.cpp and write ~/.locca/config.json pointing at
+# it. Done at build time so the image is self-contained.
+RUN locca install-llama -y -b ${LLAMA_BACKEND}
+
+# Models are bind-mounted here. LOCCA_MODELS_DIR keeps the config (which holds
+# the llama-server path) separate from the mount, so neither clobbers the other.
+ENV LOCCA_MODELS_DIR=/models
+VOLUME ["/models"]
+
+EXPOSE 8080
+
+# `serve -f` is the container's main process: it streams llama-server logs to
+# stdout (so `docker logs` works), stays up until killed, and propagates
+# SIGTERM cleanly. Append the model name as the container command, or pass
+# `-e LOCCA_MODEL=<name>`.
+ENTRYPOINT ["locca", "serve", "-f"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm link              # symlinks `locca` into your PATH
 ```
 locca                          # interactive menu (Pi is default)
 locca pi [model-pattern]       # launch pi against a local server
-locca serve                    # start llama-server with a picked model (detached)
+locca serve [model] [opts]     # start llama-server (interactive pick, or head-less: `locca serve qwen3.5-9b`)
 locca switch                   # picker: installed models + curated catalog
 locca bench                    # run llama-bench against a model
 locca doctor                   # health check: hardware, llama.cpp, server, log, config
@@ -82,6 +82,72 @@ working ones show up. Handy for pointing a phone or another machine at
 the same server.
 
 The same output prints automatically after `locca serve` succeeds.
+
+## Head-less `serve`
+
+`locca serve` is interactive by default — it prompts for the model and
+settings. Pass a model name (or set `LOCCA_MODEL`) and it runs with no
+prompts, which is what you need in Docker, systemd, or CI where there's no
+terminal:
+
+```
+locca serve qwen3.5-9b                     # config defaults, detached
+locca serve qwen3.5-9b -p 8080 -c 16384    # explicit port + context
+locca serve qwen3.5-9b -f                  # foreground: streams logs, stays up until killed
+```
+
+The model argument is a substring match against your models dir (same as
+`locca pi qwen`). With no TTY and no model named, `serve` prints a clear
+error and lists the available models instead of hanging on the picker.
+
+| Flag | Env | Default |
+|---|---|---|
+| `-p, --port` | `LOCCA_PORT` | config `defaultPort` |
+| `-c, --ctx` | `LOCCA_CTX` | config `defaultCtx` |
+| `-t, --threads` | `LOCCA_THREADS` | config `defaultThreads` |
+| `-H, --host` | `LOCCA_HOST` | `0.0.0.0` |
+| `-f, --foreground` | `LOCCA_FOREGROUND=1` | off (detached) |
+| `-y, --yes` | — | accept defaults, no prompts |
+
+`-f` (foreground) makes locca the supervisor of `llama-server`: logs go to
+stdout, SIGTERM/Ctrl-C stops it cleanly, and locca exits only when the
+server does. That's the right shape for a container's main process.
+
+## Running in Docker
+
+The repo ships a `Dockerfile` and `docker-compose.yml` that run llama.cpp's
+OpenAI-compatible server head-less — handy if you're pointing a tool like
+[SUB/WAVE](https://github.com/perminder-klair/subwave) at a local model and
+want to control the llama.cpp version and flags yourself (instead of
+whatever Ollama bundles).
+
+```bash
+# Build (CPU — runs anywhere)
+docker build -t locca .
+
+# Run: mount your GGUF models, name the model to serve
+docker run --rm -p 8080:8080 \
+    -v /path/to/models:/models:ro \
+    locca qwen3.5-9b
+```
+
+Or with compose — drop GGUFs in `./models`, set the model in
+`docker-compose.yml`, then `docker compose up -d`.
+
+Point any OpenAI-compatible client at `http://<host>:8080/v1`. In SUB/WAVE:
+**admin → Settings → LLM provider = `openai-compatible`**, base URL
+`http://locca:8080/v1` (same compose network) or `http://<host-ip>:8080/v1`
+from elsewhere. No API key is required.
+
+**Models** mount at `/models` (overridable with `LOCCA_MODELS_DIR`).
+**GPU:** build with `--build-arg LLAMA_BACKEND=vulkan` and pass
+`--device /dev/dri` (AMD/Intel) — see the commented block in
+`docker-compose.yml`. The default CPU build needs no GPU and runs anywhere.
+
+> If you hit the `GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS)` crash
+> (a known llama.cpp assert that kills the server mid-request), it's usually
+> parallel slots combined with a large context. locca defaults to
+> `--parallel 1`; lowering `LOCCA_CTX` is the other lever.
 
 ## Server defaults
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+# locca → llama.cpp OpenAI-compatible server, for SUB/WAVE and any other
+# openai-compatible client. Drop your GGUF files in ./models, then:
+#
+#   docker compose up -d
+#
+# Point SUB/WAVE at it: admin → Settings → LLM provider = openai-compatible,
+# base URL = http://locca:8080/v1 (if SUB/WAVE runs in this same compose
+# project) or http://<this-host-ip>:8080/v1 from elsewhere on the LAN.
+
+services:
+  locca:
+    build:
+      context: .
+      args:
+        # cpu (portable) or vulkan (AMD/Intel GPU — see the gpu block below)
+        LLAMA_BACKEND: cpu
+    # Model to serve: name or substring matched against files in ./models.
+    # Equivalent to `-e LOCCA_MODEL=qwen3.5-9b`.
+    command: ["qwen3.5-9b"]
+    environment:
+      # Context window. Lower this if a model won't fit (the GGML_ASSERT
+      # crash some Ollama users hit is often parallel slots × big ctx).
+      LOCCA_CTX: "16384"
+      # LOCCA_MODEL: qwen3.5-9b   # alternative to `command:` above
+    volumes:
+      - ./models:/models:ro
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    healthcheck:
+      # Node ships in the image — use it to probe llama-server's /health.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:8080/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      # Big models can take a while to load before /health goes green.
+      start_period: 180s
+
+    # ── AMD / Intel GPU (Vulkan) ────────────────────────────────────────
+    # Build with LLAMA_BACKEND: vulkan above, then uncomment:
+    # devices:
+    #   - /dev/dri:/dev/dri
+    # group_add:
+    #   - video
+    #   - render

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ async function dispatch(): Promise<void> {
     case 'serve':
     case 'start': {
       const m = await import('./commands/serve.js');
-      await m.serve();
+      await m.serve(rest);
       return;
     }
     case 'embed':

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,18 +1,142 @@
+import type { ChildProcess } from 'node:child_process';
+import { unlinkSync } from 'node:fs';
 import { basename } from 'node:path';
 import * as p from '@clack/prompts';
 import { isEmbeddingModelName, mtpArgsForModel, serverArgsForModel } from '../catalog.js';
 import { loadConfig } from '../config.js';
 import { requireLlama } from '../deps.js';
-import { pickModel, scanModels } from '../models.js';
+import { findFirstMatch, modelLine, pickModel, scanModels } from '../models.js';
 import { refuseIfPortTaken } from '../preflight.js';
-import { launchServer, serverStatus, stopServer, waitReady } from '../server.js';
+import { PIDFILE, launchServer, serverStatus, stopServer, waitReady } from '../server.js';
 import type { Model } from '../types.js';
 import { exitIfCancelled, pc } from '../ui.js';
 import { api } from './api.js';
 import { startEmbeddingSidecar } from './embed.js';
 
-export async function serve(): Promise<void> {
+interface ServeArgs {
+  pattern?: string;
+  /** True when `pattern` came from a CLI positional, so it wins over LOCCA_MODEL. */
+  patternFromCli?: boolean;
+  port?: number;
+  ctx?: number;
+  threads?: number;
+  host?: string;
+  foreground: boolean;
+  yes: boolean;
+  help: boolean;
+}
+
+const USAGE = `Usage: locca serve [model] [options]
+
+Start the OpenAI-compatible API server with a model.
+
+With no model argument and a TTY, prompts you to pick one. Pass a model
+name (or set LOCCA_MODEL) to run head-less — required in Docker / CI where
+there is no terminal to prompt on.
+
+Arguments:
+  model              Model name or substring to serve (e.g. "qwen3.5-9b"),
+                     matched against files in your models dir.
+
+Options:
+  -p, --port <n>     Port to bind        (env LOCCA_PORT,    default: config defaultPort)
+  -c, --ctx <n>      Context window      (env LOCCA_CTX,     default: config defaultCtx)
+  -t, --threads <n>  CPU threads         (env LOCCA_THREADS, default: config defaultThreads)
+  -H, --host <addr>  Address to bind     (env LOCCA_HOST,    default: 0.0.0.0)
+  -f, --foreground   Run in the foreground, streaming llama-server logs to
+                     stdout and staying up until killed — use this as a
+                     container's main process (env LOCCA_FOREGROUND=1).
+  -y, --yes          Accept defaults without prompting.
+  -h, --help         Show this help.
+
+Examples:
+  locca serve                              # interactive pick (needs a TTY)
+  locca serve qwen3.5-9b                    # head-less, config defaults
+  locca serve qwen3.5-9b -p 8080 -c 16384   # head-less, explicit settings
+  LOCCA_MODEL=qwen3.5-9b locca serve -f     # container entrypoint`;
+
+function envInt(name: string): number | undefined {
+  const v = process.env[name];
+  if (!v) return undefined;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function envFlag(name: string): boolean {
+  const v = process.env[name];
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+function parseArgs(argv: string[]): ServeArgs {
+  const out: ServeArgs = {
+    foreground: envFlag('LOCCA_FOREGROUND'),
+    yes: false,
+    help: false,
+  };
+  // Env defaults first; an explicit CLI flag below overrides them.
+  out.port = envInt('LOCCA_PORT');
+  out.ctx = envInt('LOCCA_CTX');
+  out.threads = envInt('LOCCA_THREADS');
+  if (process.env.LOCCA_HOST) out.host = process.env.LOCCA_HOST;
+  if (process.env.LOCCA_MODEL) out.pattern = process.env.LOCCA_MODEL;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    const next = (): string | undefined => argv[++i];
+    switch (a) {
+      case '-h':
+      case '--help':
+        out.help = true;
+        break;
+      case '-f':
+      case '--foreground':
+        out.foreground = true;
+        break;
+      case '-y':
+      case '--yes':
+        out.yes = true;
+        break;
+      case '-p':
+      case '--port':
+        out.port = parseInt(next() ?? '', 10) || out.port;
+        break;
+      case '-c':
+      case '--ctx':
+        out.ctx = parseInt(next() ?? '', 10) || out.ctx;
+        break;
+      case '-t':
+      case '--threads':
+        out.threads = parseInt(next() ?? '', 10) || out.threads;
+        break;
+      case '-H':
+      case '--host':
+        out.host = next() ?? out.host;
+        break;
+      default:
+        // First bare (non-flag) token is the model pattern; an explicit CLI
+        // arg wins over LOCCA_MODEL.
+        if (!a.startsWith('-') && !out.patternFromCli) {
+          out.pattern = a;
+          out.patternFromCli = true;
+        }
+    }
+  }
+  return out;
+}
+
+export async function serve(argv: string[] = []): Promise<void> {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+
   const cfg = loadConfig();
+
+  // Interactive only when we have a terminal, no model was named, and the
+  // user didn't ask to skip prompts. In a container (no TTY) we must never
+  // block on a prompt — bail with a clear message instead.
+  const interactive = Boolean(process.stdin.isTTY) && !args.pattern && !args.yes;
 
   // Check who's on the port before requiring llama-server — we may bail
   // with a more informative error.
@@ -35,6 +159,12 @@ export async function serve(): Promise<void> {
   const models = scanModels(cfg.modelsDir);
   if (models.length === 0) {
     p.log.error(`No models found in ${cfg.modelsDir}`);
+    if (!interactive) {
+      console.error(
+        `\nMount or download GGUF models into that directory first.\n` +
+          `In Docker, bind-mount your models to it or set LOCCA_MODELS_DIR.`,
+      );
+    }
     process.exit(1);
   }
 
@@ -48,69 +178,102 @@ export async function serve(): Promise<void> {
     process.exit(1);
   }
 
-  const model = await pickModel(chatModels, 'Pick a model to serve');
-  if (!model) return;
+  let model: Model | null;
+  if (args.pattern) {
+    model = findFirstMatch(chatModels, args.pattern);
+    if (!model) {
+      p.log.error(`No chat model matching '${args.pattern}' in ${cfg.modelsDir}`);
+      printAvailable(chatModels);
+      process.exit(1);
+    }
+  } else if (interactive) {
+    model = await pickModel(chatModels, 'Pick a model to serve');
+    if (!model) return;
+  } else {
+    // No TTY and no model named — can't prompt, so guide the user.
+    p.log.error(
+      `No model specified and no terminal to prompt on.\n` +
+        `Pass a model name (\`locca serve <model>\`) or set LOCCA_MODEL.`,
+    );
+    printAvailable(chatModels);
+    process.exit(1);
+  }
 
-  const choice = await p.select({
-    message: 'Settings',
-    options: [
-      { value: 'default', label: `Default (port ${cfg.defaultPort}, ctx ${cfg.defaultCtx})` },
-      { value: 'custom', label: 'Custom' },
-    ],
-  });
-  exitIfCancelled(choice);
+  let port = args.port ?? cfg.defaultPort;
+  let ctx = args.ctx ?? cfg.defaultCtx;
+  let threads = args.threads ?? cfg.defaultThreads;
+  const host = args.host ?? '0.0.0.0';
 
-  let port = cfg.defaultPort;
-  let ctx = cfg.defaultCtx;
-  let threads = cfg.defaultThreads;
-
-  if (choice === 'custom') {
-    const portIn = await p.text({
-      message: 'Port',
-      placeholder: String(cfg.defaultPort),
-      initialValue: String(cfg.defaultPort),
+  // Interactive settings prompt only when running interactively AND the user
+  // didn't already pin the values on the command line / via env.
+  const settingsPinned =
+    args.port !== undefined || args.ctx !== undefined || args.threads !== undefined;
+  if (interactive && !settingsPinned) {
+    const choice = await p.select({
+      message: 'Settings',
+      options: [
+        { value: 'default', label: `Default (port ${port}, ctx ${ctx})` },
+        { value: 'custom', label: 'Custom' },
+      ],
     });
-    exitIfCancelled(portIn);
-    port = parseInt(portIn, 10) || cfg.defaultPort;
+    exitIfCancelled(choice);
 
-    const ctxIn = await p.text({
-      message: 'Context size',
-      placeholder: String(cfg.defaultCtx),
-      initialValue: String(cfg.defaultCtx),
-    });
-    exitIfCancelled(ctxIn);
-    ctx = parseInt(ctxIn, 10) || cfg.defaultCtx;
+    if (choice === 'custom') {
+      const portIn = await p.text({
+        message: 'Port',
+        placeholder: String(port),
+        initialValue: String(port),
+      });
+      exitIfCancelled(portIn);
+      port = parseInt(portIn, 10) || port;
 
-    const threadsIn = await p.text({
-      message: 'Threads',
-      placeholder: String(cfg.defaultThreads),
-      initialValue: String(cfg.defaultThreads),
-    });
-    exitIfCancelled(threadsIn);
-    threads = parseInt(threadsIn, 10) || cfg.defaultThreads;
+      const ctxIn = await p.text({
+        message: 'Context size',
+        placeholder: String(ctx),
+        initialValue: String(ctx),
+      });
+      exitIfCancelled(ctxIn);
+      ctx = parseInt(ctxIn, 10) || ctx;
+
+      const threadsIn = await p.text({
+        message: 'Threads',
+        placeholder: String(threads),
+        initialValue: String(threads),
+      });
+      exitIfCancelled(threadsIn);
+      threads = parseInt(threadsIn, 10) || threads;
+    }
   }
 
   await refuseIfPortTaken(port);
 
-  printStartupBanner(model, port, ctx);
+  printStartupBanner(model, port, ctx, host, cfg.llamaBundled?.backend);
 
-  launchServer({
+  const child = launchServer({
     llamaServer: cfg.llamaServer,
     modelPath: model.path,
     mmprojPath: model.mmprojPath,
     port,
     ctx,
     threads,
+    host,
     extraArgs: [
       ...serverArgsForModel(basename(model.path)),
       ...mtpArgsForModel(model.path, cfg, cfg.llamaServer),
     ],
     noMmap: cfg.noMmap,
     parallel: cfg.defaultParallel,
-    // Detached: server keeps running after locca exits. Stop it with
-    // `locca stop`. Logs go to the log file (see `locca logs`).
-    detached: true,
+    // Foreground: llama-server inherits our stdio and we block until it
+    // exits — the right shape for a container's main process (logs go to
+    // `docker logs`, SIGTERM stops the container, no orphaned daemon).
+    // Otherwise detach and return, leaving the server up (`locca stop`).
+    detached: !args.foreground,
   });
+
+  if (args.foreground) {
+    await runForeground(child, host, port, basename(model.path));
+    return;
+  }
 
   const ready = await waitReady(port, 60);
   if (!ready) {
@@ -134,13 +297,89 @@ export async function serve(): Promise<void> {
   console.log();
 }
 
-function printStartupBanner(model: Model, port: number, ctx: number): void {
+/**
+ * Foreground supervisor for container use: forward termination signals to
+ * llama-server, clean up the PIDFILE, and resolve when the child exits so
+ * the process (and the container) lives exactly as long as the server.
+ */
+async function runForeground(
+  child: ChildProcess,
+  host: string,
+  port: number,
+  modelId: string,
+): Promise<void> {
+  const advertise = host === '0.0.0.0' || host === '::' ? 'localhost' : host;
+  console.log(
+    `  ${pc.green('●')} Serving ${pc.cyan(modelId)} on ${pc.cyan(`http://${advertise}:${port}/v1`)}`,
+  );
+  console.log(`  ${pc.dim('Bound to')} ${host}:${port} ${pc.dim('— Ctrl-C / SIGTERM to stop')}`);
+  console.log();
+
+  const forward = (sig: NodeJS.Signals) => {
+    try {
+      child.kill(sig);
+    } catch {
+      // already gone
+    }
+  };
+  process.on('SIGTERM', () => forward('SIGTERM'));
+  process.on('SIGINT', () => forward('SIGINT'));
+
+  await new Promise<void>((resolve) => {
+    child.on('exit', (code, signal) => {
+      cleanupPidfile();
+      process.exitCode = signal ? 0 : (code ?? 0);
+      resolve();
+    });
+    child.on('error', (err) => {
+      cleanupPidfile();
+      p.log.error(`Failed to start llama-server: ${err.message}`);
+      process.exitCode = 1;
+      resolve();
+    });
+  });
+}
+
+function cleanupPidfile(): void {
+  try {
+    unlinkSync(PIDFILE);
+  } catch {
+    // never created or already gone
+  }
+}
+
+function printAvailable(models: Model[]): void {
+  if (models.length === 0) return;
+  console.error(`\nAvailable models:`);
+  for (const m of models.slice(0, 30)) {
+    console.error(`  ${modelLine(m)}`);
+  }
+  if (models.length > 30) console.error(`  …and ${models.length - 30} more`);
+}
+
+function printStartupBanner(
+  model: Model,
+  port: number,
+  ctx: number,
+  host: string,
+  backend?: string,
+): void {
   console.log();
   console.log(pc.magenta(pc.bold('  Starting server...')));
   console.log(`  Model:   ${model.name}`);
+  console.log(`  Host:    ${host}`);
   console.log(`  Port:    ${port}`);
   console.log(`  Context: ${ctx}`);
-  console.log(`  GPU:     Vulkan (all layers)`);
+  // We always pass `--n-gpu-layers 999`; the actual backend depends on the
+  // llama.cpp build. Name it when we know it (bundled installs record it),
+  // otherwise stay generic rather than claiming Vulkan on a CPU build.
+  const accel =
+    backend && backend !== 'cpu'
+      ? `${backend} (all layers)`
+      : backend === 'cpu'
+        ? 'CPU'
+        : 'GPU offload (--n-gpu-layers 999)';
+  console.log(`  Accel:   ${accel}`);
   if (model.mmprojPath) {
     const f = model.mmprojPath.split('/').pop();
     console.log(`  Vision:  ${f}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,22 +32,30 @@ export function configExists(): boolean {
 
 export function loadConfig(): Config {
   const base = defaults();
-  if (!existsSync(CONFIG_FILE)) return base;
-  try {
-    const raw = JSON.parse(readFileSync(CONFIG_FILE, 'utf8')) as Partial<Config> & {
-      piSkills?: Config['piSkills'] | boolean;
-    };
-    // Migrate legacy boolean piSkills → tri-state. true was the old "skills on"
-    // and false was the old "--no-skills" — neither matches the new default of
-    // 'lazy', so we preserve the user's prior intent rather than forcing it.
-    const { piSkills, ...rest } = raw;
-    const coerced: Partial<Config> = { ...rest };
-    if (typeof piSkills === 'boolean') coerced.piSkills = piSkills ? 'on' : 'off';
-    else if (piSkills !== undefined) coerced.piSkills = piSkills;
-    return { ...base, ...coerced };
-  } catch {
-    return base;
+  let cfg = base;
+  if (existsSync(CONFIG_FILE)) {
+    try {
+      const raw = JSON.parse(readFileSync(CONFIG_FILE, 'utf8')) as Partial<Config> & {
+        piSkills?: Config['piSkills'] | boolean;
+      };
+      // Migrate legacy boolean piSkills → tri-state. true was the old "skills on"
+      // and false was the old "--no-skills" — neither matches the new default of
+      // 'lazy', so we preserve the user's prior intent rather than forcing it.
+      const { piSkills, ...rest } = raw;
+      const coerced: Partial<Config> = { ...rest };
+      if (typeof piSkills === 'boolean') coerced.piSkills = piSkills ? 'on' : 'off';
+      else if (piSkills !== undefined) coerced.piSkills = piSkills;
+      cfg = { ...base, ...coerced };
+    } catch {
+      cfg = base;
+    }
   }
+  // Env override for the models dir — there's no config file to edit inside a
+  // container, so this is how a Docker image points at a bind-mounted volume.
+  if (process.env.LOCCA_MODELS_DIR) {
+    cfg = { ...cfg, modelsDir: process.env.LOCCA_MODELS_DIR };
+  }
+  return cfg;
 }
 
 export function saveConfig(patch: Partial<Config>): Config {


### PR DESCRIPTION
## Why

On [subwave#314](https://github.com/perminder-klair/subwave/issues/314) we pointed users hitting the Ollama `GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS)` crash at locca, so they could control the llama.cpp version and flags themselves. Two of them (`diablo581`, `WhatKateDoes`) then got stuck trying to run locca **in a container** — because `locca serve` is fully interactive and just hangs with no TTY. This makes the thing we recommended actually drivable head-less.

## What

**Head-less `serve`** — `locca serve` now accepts a model name/substring plus flags, skipping all prompts:

```
locca serve qwen3.5-9b [-p PORT] [-c CTX] [-t THREADS] [-H HOST] [-f] [-y]
```

- Env fallbacks: `LOCCA_MODEL / PORT / CTX / THREADS / HOST / FOREGROUND`.
- Model arg is a substring match against the models dir (same UX as `locca pi qwen`).
- No TTY + no model named → clear error listing available models, instead of hanging on the picker.
- `-f, --foreground` makes locca the supervisor of `llama-server`: logs to stdout, SIGTERM/Ctrl-C clean, exits with the server — the right shape for a container's main process.
- Interactive behaviour is unchanged when run with a TTY and no args.

**`LOCCA_MODELS_DIR`** override in `loadConfig()` so a container points at a bind-mounted volume without needing a config file.

**Official Docker support** — multi-stage `Dockerfile` (CPU default, `LLAMA_BACKEND=vulkan` opt-in), `docker-compose.yml` (models volume, healthcheck, SUB/WAVE wiring notes, commented GPU block), `.dockerignore`.

**Banner fix** — the startup banner reflected the bundled backend instead of always printing `Vulkan` (misleading on a CPU build → now `Accel: CPU`).

## Verification

Built the image and confirmed in-container:
- `serve --help` renders.
- No-model/no-TTY guard prints "No models found" + Docker hint.
- A mounted model resolves and the **bundled** `llama-server` launches, streaming logs to stdout.
- Banner shows `Accel: CPU` on the CPU build.

`npm run build` is clean (strict TS). GPU passthrough (Vulkan/`/dev/dri`) was not exercised on CI hardware — documented but unverified end-to-end.

## Usage

```bash
docker build -t locca .
docker run --rm -p 8080:8080 -v /path/to/models:/models:ro locca qwen3.5-9b
```

SUB/WAVE: admin → Settings → LLM provider = `openai-compatible`, base URL `http://locca:8080/v1`.