### PR TITLE
feat(serve): foreground mode + Docker support + LOCCA_MODELS_DIR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.claude
+.vscode
+.zed
+test
+docs
+*.log
+npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ Every command that needs an LLM calls `serverStatus(cfg)`, which classifies the 
 
 `waitReady()` polls `/health`, **not** `/v1/models` — `/health` flips green when the HTTP listener binds, while `/v1/models` only answers post-weights-load. On big models that's a 10–30s gap that previously caused spurious timeouts.
 
+`launchServer()` returns the `ChildProcess` and runs in one of two modes. **Detached** (the default for `serve`/`embed`): stdio to the logfile, `child.unref()`, PIDFILE written, locca exits leaving the server up. **Foreground** (`detached: false` → `stdio: 'inherit'`): locca stays attached. `serve -f` is the only foreground caller — `superviseForeground()` (`src/commands/serve.ts`) forwards SIGTERM/SIGINT to the child, removes the PIDFILE, and exits with the server's exit code, which is the shape a container's PID 1 / a systemd unit needs. `serve` also treats **no TTY** as non-interactive (resolve the named or sole chat model, never block on the Clack picker) so it can't hang head-less.
+
 ### Model discovery & context tuning — `src/models.ts`
 
 `scanModels()` walks `cfg.modelsDir` recursively, skipping `mmproj*.gguf` (vision adapters, attached to their parent model) and `ggml-vocab-*.gguf` (llama.cpp tokenizer fixtures, no weights).
@@ -47,7 +49,7 @@ The `pi` command branches on two states: attached server (use the model it repor
 
 ### Config — `src/config.ts`
 
-`~/.locca/config.json`. Written with `mode 0o600`. `loadConfig()` merges over `defaults()` so older configs missing newer keys keep working without migration.
+`~/.locca/config.json`. Written with `mode 0o600`. `loadConfig()` merges over `defaults()` so older configs missing newer keys keep working without migration. After the merge, `LOCCA_MODELS_DIR` (if set) overrides `modelsDir` — the escape hatch for containers / environments with no config file to edit (the Docker image sets it to `/models`).
 
 ### Distro detection — `src/distro.ts`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+#
+# locca in a container — runs llama.cpp's OpenAI-compatible server head-less.
+#
+# Point any OpenAI-compatible client (e.g. SUB/WAVE: provider =
+# openai-compatible) at http://<host>:8080/v1. See README "Running in Docker".
+#
+#   docker build -t locca .                       # CPU build (runs anywhere)
+#   docker build -t locca:vulkan \                # AMD/Intel GPU via Vulkan
+#       --build-arg LLAMA_BACKEND=vulkan .
+#
+#   docker run --rm -p 8080:8080 \
+#       -v /path/to/models:/models:ro \
+#       locca qwen3.5-9b           # model name (substring match)
+
+# ── Stage 1: build locca from source ────────────────────────────────────
+FROM node:22-bookworm AS build
+WORKDIR /src
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+COPY bin ./bin
+RUN npm run build && npm prune --omit=dev
+
+# ── Stage 2: runtime ────────────────────────────────────────────────────
+FROM node:22-bookworm-slim AS runtime
+
+# Backend for the bundled llama.cpp:
+#   cpu    — portable, runs on any host (default)
+#   vulkan — AMD / Intel GPU; needs `--device /dev/dri` at run time and the
+#            mesa ICD installed below
+ARG LLAMA_BACKEND=cpu
+
+# unzip       — llama.cpp release assets are .zip
+# ca-certs    — TLS to GitHub for `install-llama`
+# libgomp1    — OpenMP runtime the prebuilt llama-server links against
+# libcurl4    — recent llama-server builds link libcurl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates unzip libgomp1 libcurl4 \
+ && if [ "$LLAMA_BACKEND" = "vulkan" ]; then \
+      apt-get install -y --no-install-recommends libvulkan1 mesa-vulkan-drivers; \
+    fi \
+ && rm -rf /var/lib/apt/lists/*
+
+# locca itself (built in stage 1).
+COPY --from=build /src /opt/locca
+RUN ln -s /opt/locca/bin/locca /usr/local/bin/locca
+
+# Download the prebuilt llama.cpp and write ~/.locca/config.json pointing at
+# it. Done at build time so the image is self-contained.
+RUN locca install-llama -y -b ${LLAMA_BACKEND}
+
+# Models are bind-mounted here. LOCCA_MODELS_DIR keeps the config (which holds
+# the llama-server path) separate from the mount, so neither clobbers the other.
+ENV LOCCA_MODELS_DIR=/models
+VOLUME ["/models"]
+
+EXPOSE 8080
+
+# `serve -f` (foreground) is the container's main process: it streams
+# llama-server logs to stdout (so `docker logs` works), stays up until killed,
+# and propagates SIGTERM cleanly. Append the model name as the container
+# command (CMD / `docker run ... locca <model>`).
+ENTRYPOINT ["locca", "serve", "-f"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ npm link              # symlinks `locca` into your PATH
 locca                          # interactive menu (Pi is default)
 locca pi [model-pattern]       # launch pi against a local server
 locca serve [model] [opts]     # start llama-server (interactive pick, or head-less: `locca serve qwen3.5-9b`)
+locca embed [model]            # start a dedicated embedding server (separate port)
 locca switch                   # picker: installed models + curated catalog
 locca bench                    # run llama-bench against a model
 locca doctor                   # health check: hardware, llama.cpp, server, log, config
 locca optimise                 # ask pi to review the deployment and suggest tweaks
 locca api                      # print OpenAI-compatible connection info
-locca logs                     # tail server log (locca-started servers only)
+locca logs [embed]             # tail server log (chat by default, or the embed server)
 locca download [user/repo]     # pull a GGUF from HuggingFace
 locca search   [query]         # search HuggingFace for GGUF models
 locca delete                   # remove a model directory

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm link              # symlinks `locca` into your PATH
 ```
 locca                          # interactive menu (Pi is default)
 locca pi [model-pattern]       # launch pi against a local server
-locca serve                    # start llama-server with a picked model (detached)
+locca serve [model] [opts]     # start llama-server (interactive pick, or head-less: `locca serve qwen3.5-9b`)
 locca switch                   # picker: installed models + curated catalog
 locca bench                    # run llama-bench against a model
 locca doctor                   # health check: hardware, llama.cpp, server, log, config
@@ -82,6 +82,59 @@ working ones show up. Handy for pointing a phone or another machine at
 the same server.
 
 The same output prints automatically after `locca serve` succeeds.
+
+## Head-less `serve`
+
+`locca serve` is interactive by default — it prompts for the model and
+settings. Pass a model name (substring-matched against your models dir, same
+as `locca pi qwen`) and it runs with no prompts, which is what you need in
+Docker, systemd, or CI:
+
+```
+locca serve qwen3.5-9b                       # config defaults, detached
+locca serve qwen3.5-9b --port 8080 --ctx 16384   # explicit port + context
+locca serve qwen3.5-9b -f                     # foreground: streams logs, stays up until killed
+```
+
+With no TTY (a container, a pipe, CI) `serve` never blocks on the picker: it
+resolves the named model, or — with none named — the sole chat model if
+there's exactly one, otherwise it lists the candidates and exits.
+
+`-f, --foreground` makes locca the supervisor of `llama-server`: logs go to
+stdout, SIGTERM/Ctrl-C stops it cleanly, the PIDFILE is removed, and locca
+exits only when the server does. That's the right shape for a container's
+main process (the default is detached — `locca stop` to stop it).
+
+## Running in Docker
+
+The repo ships a `Dockerfile` and `docker-compose.yml` that run llama.cpp's
+OpenAI-compatible server head-less — handy when you're pointing a tool at a
+local model and want to control the llama.cpp version and flags yourself
+(instead of whatever Ollama bundles).
+
+```bash
+# Build (CPU — runs anywhere)
+docker build -t locca .
+
+# Run: mount your GGUF models, name the model to serve
+docker run --rm -p 8080:8080 \
+    -v /path/to/models:/models:ro \
+    locca qwen3.5-9b
+```
+
+Or with compose — drop GGUFs in `./models`, set the model in
+`docker-compose.yml`, then `docker compose up -d`.
+
+Point any OpenAI-compatible client at `http://<host>:8080/v1` (no API key).
+**Models** mount at `/models` (overridable with `LOCCA_MODELS_DIR`).
+**GPU:** build with `--build-arg LLAMA_BACKEND=vulkan` and pass
+`--device /dev/dri` (AMD/Intel) — see the commented block in
+`docker-compose.yml`. The default CPU build needs no GPU.
+
+> If you hit the `GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS)` crash
+> (a known llama.cpp assert that kills the server mid-request), it's usually
+> parallel slots combined with a large context. locca defaults to
+> `--parallel 1`; lowering `--ctx` is the other lever.
 
 ## Server defaults
 
@@ -193,6 +246,10 @@ by hand, or re-run the wizard:
 
 The interactive editor shows preset pickers for `defaultCtx`,
 `defaultThreads`, and `vramBudgetMB`, with a `Custom…` fallback.
+
+`LOCCA_MODELS_DIR` overrides `modelsDir` at load time — for containers and
+other environments where there's no config file to edit (it's how the Docker
+image points at a bind-mounted `/models` volume).
 
 If your binaries aren't on `$PATH`, point them at absolute paths:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+# locca → llama.cpp OpenAI-compatible server, for SUB/WAVE and any other
+# openai-compatible client. Drop your GGUF files in ./models, then:
+#
+#   docker compose up -d
+#
+# Point a client at it: provider = openai-compatible, base URL =
+# http://locca:8080/v1 (if the client runs in this same compose project) or
+# http://<this-host-ip>:8080/v1 from elsewhere on the LAN. No API key needed.
+
+services:
+  locca:
+    build:
+      context: .
+      args:
+        # cpu (portable) or vulkan (AMD/Intel GPU — see the gpu block below)
+        LLAMA_BACKEND: cpu
+    # Model to serve (name or substring matched against files in ./models),
+    # followed by any `locca serve` flags. `--ctx` lowers the context window
+    # if a model won't fit (the GGML_ASSERT crash some Ollama users hit is
+    # often parallel slots × big ctx; locca already defaults to --parallel 1).
+    command: ["qwen3.5-9b", "--ctx", "16384"]
+    volumes:
+      - ./models:/models:ro
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    healthcheck:
+      # Node ships in the image — use it to probe llama-server's /health.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:8080/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      # Big models can take a while to load before /health goes green.
+      start_period: 180s
+
+    # ── AMD / Intel GPU (Vulkan) ────────────────────────────────────────
+    # Build with LLAMA_BACKEND: vulkan above, then uncomment:
+    # devices:
+    #   - /dev/dri:/dev/dri
+    # group_add:
+    #   - video
+    #   - render

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,9 +7,10 @@ function printHelp(): void {
   console.log(`Usage: locca [command]
 
 Inference:
-  serve [name]  Start API server with a model (detached). With a model
-                name (+ optional --port/--ctx/--threads/--yes) it runs
-                non-interactively — no prompts.
+  serve [name]  Start API server with a model. With a model name (+ optional
+                --port/--ctx/--threads/--yes) it runs non-interactively — no
+                prompts. Add -f/--foreground to supervise it in the foreground
+                (logs to stdout, exits with the server — for Docker / systemd).
   embed [name]  Start a dedicated embedding server (separate port)
   pi [name]     Launch pi coding agent with a local model
   switch        Stop current server and start a new model with pi

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,3 +1,5 @@
+import type { ChildProcess } from 'node:child_process';
+import { unlinkSync } from 'node:fs';
 import { basename } from 'node:path';
 import * as p from '@clack/prompts';
 import { isEmbeddingModelName, mtpArgsForModel, serverArgsForModel } from '../catalog.js';
@@ -5,7 +7,7 @@ import { loadConfig } from '../config.js';
 import { requireLlama } from '../deps.js';
 import { findFirstMatch, pickModel, scanModels } from '../models.js';
 import { refuseIfPortTaken } from '../preflight.js';
-import { launchServer, serverStatus, stopServer, waitReady } from '../server.js';
+import { PIDFILE, launchServer, serverStatus, stopServer, waitReady } from '../server.js';
 import type { Config, Model } from '../types.js';
 import { exitIfCancelled, pc } from '../ui.js';
 import { api } from './api.js';
@@ -20,10 +22,14 @@ interface ServeArgs {
   ctx?: number;
   threads?: number;
   yes: boolean;
+  // Foreground: locca supervises llama-server in the foreground instead of
+  // detaching — logs stream to stdout, SIGTERM/Ctrl-C stops it cleanly, and
+  // locca exits with the server. The right shape for a container's PID 1.
+  foreground: boolean;
 }
 
 function parseServeArgs(rest: string[]): ServeArgs {
-  const out: ServeArgs = { yes: false };
+  const out: ServeArgs = { yes: false, foreground: false };
   const num = (s: string | undefined): number | undefined => {
     const n = parseInt(s ?? '', 10);
     return Number.isFinite(n) ? n : undefined;
@@ -31,6 +37,7 @@ function parseServeArgs(rest: string[]): ServeArgs {
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i];
     if (a === '--yes' || a === '-y') out.yes = true;
+    else if (a === '--foreground' || a === '-f') out.foreground = true;
     else if (a === '--port') out.port = num(rest[++i]);
     else if (a.startsWith('--port=')) out.port = num(a.slice('--port='.length));
     else if (a === '--ctx') out.ctx = num(rest[++i]);
@@ -46,8 +53,10 @@ export async function serve(rest: string[] = []): Promise<void> {
   const cfg = loadConfig();
   const args = parseServeArgs(rest);
   // A pattern or `--yes` means "don't prompt me" — used by scripts and by a
-  // parent process that wants to bring a specific model up unattended.
-  const nonInteractive = args.pattern !== undefined || args.yes;
+  // parent process that wants to bring a specific model up unattended. No TTY
+  // (a container, a pipe, CI) is treated the same way: we can't prompt, so we
+  // resolve from the pattern / sole chat model instead of hanging on a picker.
+  const nonInteractive = args.pattern !== undefined || args.yes || !process.stdin.isTTY;
 
   // Check who's on the port before requiring llama-server — we may bail
   // with a more informative error.
@@ -97,7 +106,7 @@ export async function serve(rest: string[] = []): Promise<void> {
     : await promptSettings(cfg);
 
   await refuseIfPortTaken(port);
-  await launchModel(cfg, model, { port, ctx, threads });
+  await launchModel(cfg, model, { port, ctx, threads, foreground: args.foreground });
 }
 
 // Resolve the model in non-interactive mode. A pattern fuzzy-matches the full
@@ -172,18 +181,24 @@ async function promptSettings(
   return { port, ctx, threads };
 }
 
-// Launch llama-server for a resolved model and wait for it to come up. Shared
-// by the interactive and non-interactive paths so both produce an identical
-// end state (detached server, api block printed). Server keeps running after
-// locca exits — stop it with `locca stop`, logs via `locca logs`.
+// Launch llama-server for a resolved model. Shared by the interactive and
+// non-interactive paths. Detached (the default) leaves the server running
+// after locca exits — stop it with `locca stop`, logs via `locca logs`, and
+// the api block is printed. Foreground keeps locca attached as the server's
+// supervisor (logs to stdout, exits with it) — a container's main process.
 async function launchModel(
   cfg: Config,
   model: Model,
-  { port, ctx, threads }: { port: number; ctx: number; threads: number },
+  {
+    port,
+    ctx,
+    threads,
+    foreground,
+  }: { port: number; ctx: number; threads: number; foreground: boolean },
 ): Promise<void> {
   printStartupBanner(model, port, ctx);
 
-  launchServer({
+  const child = launchServer({
     llamaServer: cfg.llamaServer,
     modelPath: model.path,
     mmprojPath: model.mmprojPath,
@@ -196,8 +211,15 @@ async function launchModel(
     ],
     noMmap: cfg.noMmap,
     parallel: cfg.defaultParallel,
-    detached: true,
+    // Foreground → inherit stdio and block until the server exits; detached →
+    // background the server and return so the api block can print.
+    detached: !foreground,
   });
+
+  if (foreground) {
+    await superviseForeground(child, port, basename(model.path));
+    return;
+  }
 
   const ready = await waitReady(port, 60);
   if (!ready) {
@@ -219,6 +241,59 @@ async function launchModel(
   await api();
   console.log(`  ${pc.dim('Stop with: locca stop  |  Logs: locca logs')}`);
   console.log();
+}
+
+/**
+ * Foreground supervisor for container / systemd use: forward termination
+ * signals to llama-server, clean up the PIDFILE, and resolve only when the
+ * child exits — so the locca process (and the container) lives exactly as
+ * long as the server does. Server stdout/stderr is already inherited, so its
+ * logs stream straight to ours (i.e. `docker logs`).
+ */
+async function superviseForeground(
+  child: ChildProcess,
+  port: number,
+  modelId: string,
+): Promise<void> {
+  console.log(
+    `  ${pc.green('●')} Serving ${pc.cyan(modelId)} at ${pc.cyan(`http://localhost:${port}/v1`)} ${pc.dim('(bound to 0.0.0.0)')}`,
+  );
+  console.log(`  ${pc.dim('Ctrl-C / SIGTERM to stop — server logs stream below')}`);
+  console.log();
+
+  const forward = (sig: NodeJS.Signals) => {
+    try {
+      child.kill(sig);
+    } catch {
+      // already gone
+    }
+  };
+  process.on('SIGTERM', () => forward('SIGTERM'));
+  process.on('SIGINT', () => forward('SIGINT'));
+
+  await new Promise<void>((resolve) => {
+    child.on('exit', (code, signal) => {
+      cleanupPidfile();
+      // A clean signal stop is success; otherwise propagate the server's exit
+      // code so `docker run` / systemd see the real failure.
+      process.exitCode = signal ? 0 : (code ?? 0);
+      resolve();
+    });
+    child.on('error', (err) => {
+      cleanupPidfile();
+      p.log.error(`Failed to start llama-server: ${err.message}`);
+      process.exitCode = 1;
+      resolve();
+    });
+  });
+}
+
+function cleanupPidfile(): void {
+  try {
+    unlinkSync(PIDFILE);
+  } catch {
+    // never created or already gone
+  }
 }
 
 function printStartupBanner(model: Model, port: number, ctx: number): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,22 +32,31 @@ export function configExists(): boolean {
 
 export function loadConfig(): Config {
   const base = defaults();
-  if (!existsSync(CONFIG_FILE)) return base;
-  try {
-    const raw = JSON.parse(readFileSync(CONFIG_FILE, 'utf8')) as Partial<Config> & {
-      piSkills?: Config['piSkills'] | boolean;
-    };
-    // Migrate legacy boolean piSkills → tri-state. true was the old "skills on"
-    // and false was the old "--no-skills" — neither matches the new default of
-    // 'lazy', so we preserve the user's prior intent rather than forcing it.
-    const { piSkills, ...rest } = raw;
-    const coerced: Partial<Config> = { ...rest };
-    if (typeof piSkills === 'boolean') coerced.piSkills = piSkills ? 'on' : 'off';
-    else if (piSkills !== undefined) coerced.piSkills = piSkills;
-    return { ...base, ...coerced };
-  } catch {
-    return base;
+  let cfg = base;
+  if (existsSync(CONFIG_FILE)) {
+    try {
+      const raw = JSON.parse(readFileSync(CONFIG_FILE, 'utf8')) as Partial<Config> & {
+        piSkills?: Config['piSkills'] | boolean;
+      };
+      // Migrate legacy boolean piSkills → tri-state. true was the old "skills on"
+      // and false was the old "--no-skills" — neither matches the new default of
+      // 'lazy', so we preserve the user's prior intent rather than forcing it.
+      const { piSkills, ...rest } = raw;
+      const coerced: Partial<Config> = { ...rest };
+      if (typeof piSkills === 'boolean') coerced.piSkills = piSkills ? 'on' : 'off';
+      else if (piSkills !== undefined) coerced.piSkills = piSkills;
+      cfg = { ...base, ...coerced };
+    } catch {
+      cfg = base;
+    }
   }
+  // Env override for the models dir: a container has no config file to edit,
+  // so this is how a Docker image points locca at a bind-mounted volume
+  // without baking the path into config.json.
+  if (process.env.LOCCA_MODELS_DIR) {
+    cfg = { ...cfg, modelsDir: process.env.LOCCA_MODELS_DIR };
+  }
+  return cfg;
 }
 
 export function saveConfig(patch: Partial<Config>): Config {


### PR DESCRIPTION
## Why

Builds on the non-interactive `serve` path from #11 so locca can run as a **container's main process** — the use case from #9 (pointing an OpenAI-compatible client at a local model in Docker, controlling the llama.cpp version/flags yourself instead of whatever Ollama bundles). #11 landed the head-less *resolution*; this adds the foreground supervisor and the Docker packaging on top, reconciled into #11's structure (no `server.ts` changes).

## What

- **`-f, --foreground`** — locca supervises `llama-server` in the foreground instead of detaching: stdio inherited (logs stream to stdout / `docker logs`), `SIGTERM`/Ctrl-C forwarded and stops it cleanly, PIDFILE removed, and locca exits with the server's exit code. Detached stays the default; `launchModel()` branches on the flag so both paths share one launch.
- **No-TTY ⇒ non-interactive** — a container / pipe / CI resolves the named (or sole chat) model instead of blocking forever on the Clack picker.
- **`LOCCA_MODELS_DIR`** — overrides `modelsDir` at load time, so a Docker image points at a bind-mounted volume with no config file to edit.
- **Official Docker support** — multi-stage `Dockerfile` (CPU default, `--build-arg LLAMA_BACKEND=vulkan` opt-in), `docker-compose.yml` (models volume, `/health` healthcheck, commented GPU block), `.dockerignore`. Entrypoint is `locca serve -f`.
- **Docs** — README "Head-less `serve`" + "Running in Docker" sections, `LOCCA_MODELS_DIR` note, and `-f` in the CLI help.

```bash
docker build -t locca .
docker run --rm -p 8080:8080 -v /path/to/models:/models:ro locca qwen3.5-9b
```

## Verification

- `npm run build` clean (strict TS).
- Head-less, no TTY, bad model name → lists candidates, exits 1, **no hang**.
- Foreground with a small model (`LFM2.5-1.2B`): banner + streamed llama-server logs, PIDFILE written, `/health` up in 3s, `SIGTERM` → **exit 0**, PIDFILE removed, port down, no leftover `llama-server` processes.
- GPU/Vulkan passthrough (`/dev/dri`) documented but not exercised on this hardware.

## Relationship to #9

This supersedes the head-less-serve core of #9 (which now conflicts with merged #11) and brings across its still-unmerged value: Docker, `LOCCA_MODELS_DIR`, and foreground mode. #9 can be closed once this lands.

## Out of scope (follow-ups)

- Startup banner still prints `GPU: Vulkan` even on a CPU build (misleading in the CPU Docker image).
- `serve` stops a running server *before* validating the requested model, so a typo'd name takes down a live server. Pre-existing.