### PR TITLE
feat(serve): --idle-timeout — unload VRAM on idle, reload on demand (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ stdout, SIGTERM/Ctrl-C stops it cleanly, the PIDFILE is removed, and locca
 exits only when the server does. That's the right shape for a container's
 main process (the default is detached — `locca stop` to stop it).
 
+## Idle VRAM unload (`--idle-timeout`)
+
+`llama-server` keeps the model resident in VRAM for its whole lifetime. Pass
+`--idle-timeout` and `locca serve` instead runs a small foreground reverse-proxy
+that unloads the model after it sits idle, freeing the VRAM, and transparently
+reloads it on the next request:
+
+```
+locca serve qwen3.5-9b --idle-timeout 15m    # free VRAM after 15 min idle
+locca serve qwen3.5-9b --idle-timeout 30s    # also accepts s / h, or bare seconds
+```
+
+The proxy binds your `--port` (default `8080`); `llama-server` runs privately on
+`port + 1` (bound to `127.0.0.1`). The model loads eagerly at start, so the
+first requests are fast. Only real inference resets the idle clock — a
+`/health` or `/v1/models` poll won't keep the model pinned. Like `-f`, it runs
+in the foreground (Ctrl-C / SIGTERM stops it); background it yourself
+(`nohup`/`&`/tmux) on a desktop.
+
+**Caveat:** the first request after an unload pays the weights-load latency
+(roughly 10–30s on large models). The proxy holds the connection open while the
+model reloads, so a client with an aggressive timeout may give up on that first
+cold request.
+
 ## Running in Docker
 
 The repo ships a `Dockerfile` and `docker-compose.yml` that run llama.cpp's

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm link              # symlinks `locca` into your PATH
 ```
 locca                          # interactive menu (Pi is default)
 locca pi [model-pattern]       # launch pi against a local server
-locca serve [model] [opts]     # start llama-server (interactive pick, or head-less: `locca serve qwen3.5-9b`)
+locca serve [model] [opts]     # start llama-server — interactive, head-less, -f foreground, or --idle-timeout
 locca embed [model]            # start a dedicated embedding server (separate port)
 locca switch                   # picker: installed models + curated catalog
 locca bench                    # run llama-bench against a model

--- a/docs/index.html
+++ b/docs/index.html
@@ -977,6 +977,39 @@ median  pp <span class="ok">1851</span> t/s   tg <span class="ok">142</span> t/s
               <span style="color:var(--teal)">attached</span>, and uses it instead of spawning a duplicate.
             </p>
           </div>
+          <div class="feature">
+            <div class="glyph" aria-hidden="true">⏏</div>
+            <h3>Free VRAM when idle</h3>
+            <p>
+              <code translate="no">locca serve qwen --idle-timeout 15m</code> runs a
+              small proxy that drops the model after it sits unused, freeing the
+              VRAM, then reloads it on the next request. Only real inference
+              resets the clock — a <code translate="no">/health</code> poll won't
+              keep it pinned.
+            </p>
+          </div>
+          <div class="feature">
+            <div class="glyph" aria-hidden="true">⧉</div>
+            <h3>Headless &amp; container-ready</h3>
+            <p>
+              Name a model and <code translate="no">locca serve qwen3.5-9b --yes</code>
+              runs with no prompts. <code translate="no">-f</code> supervises it in
+              the foreground so it can be a container's PID 1 or a systemd unit —
+              the repo ships a <code translate="no">Dockerfile</code>, and
+              <code translate="no">LOCCA_MODELS_DIR</code> points it at a mounted volume.
+            </p>
+          </div>
+          <div class="feature">
+            <div class="glyph" aria-hidden="true">⇶</div>
+            <h3>Embeddings, too</h3>
+            <p>
+              <code translate="no">locca embed nomic-embed</code> brings up a
+              dedicated embedding server on its own port, tuned with the
+              <code translate="no">--pooling</code> and ubatch flags that
+              <code translate="no">/v1/embeddings</code> needs — running side by
+              side with your chat model.
+            </p>
+          </div>
         </div>
       </div>
     </section>
@@ -1066,7 +1099,8 @@ Ask before anything destructive or anything needing sudo. If a step fails, show 
 
         <ul class="cmd-grid">
           <li class="cmd-row"><code translate="no">locca pi</code><span>Launch the pi coding agent against your local server.</span></li>
-          <li class="cmd-row"><code translate="no">locca serve</code><span>Start <code translate="no" style="font-family:var(--mono)">llama-server</code> with a picked model, detached.</span></li>
+          <li class="cmd-row"><code translate="no">locca serve</code><span>Start <code translate="no" style="font-family:var(--mono)">llama-server</code> with a model — detached, head-less <code translate="no" style="font-family:var(--mono)">--yes</code>, foreground <code translate="no" style="font-family:var(--mono)">-f</code>, or <code translate="no" style="font-family:var(--mono)">--idle-timeout</code> to free VRAM when idle.</span></li>
+          <li class="cmd-row"><code translate="no">locca embed</code><span>Start a dedicated embedding server on its own port.</span></li>
           <li class="cmd-row"><code translate="no">locca switch</code><span>Catalog-aware picker — installed models + curated catalog with fit hints.</span></li>
           <li class="cmd-row"><code translate="no">locca bench</code><span>Run llama-bench with a friendlier summary.</span></li>
           <li class="cmd-row"><code translate="no">locca doctor</code><span>Health check — hardware, server, log warnings, config sanity.</span></li>

--- a/docs/superpowers/specs/2026-06-17-idle-timeout-proxy-design.md
+++ b/docs/superpowers/specs/2026-06-17-idle-timeout-proxy-design.md
@@ -1,0 +1,113 @@
+# Design: `locca serve --idle-timeout` — idle VRAM unload + reload-on-demand
+
+Date: 2026-06-17
+Issue: https://github.com/perminder-klair/locca/issues/13
+Status: approved
+
+## Problem
+
+`llama-server` keeps model weights resident in VRAM for its whole lifetime —
+there is no native "unload when idle, reload on demand" flag. locca's default
+`serve` path spawns `llama-server` detached and then **exits**, so there is no
+resident locca process to watch idle time or to catch the request that should
+trigger a reload.
+
+The reporter wants a flag to free VRAM after the model sits unused for a
+configurable period (e.g. 15 min), reloading it transparently on the next
+request.
+
+## Solution overview
+
+Add `locca serve <model> --idle-timeout <duration>`: a **foreground**
+reverse-proxy supervised by locca itself. It loads the model eagerly (serve
+still serves), proxies inference to a private `llama-server`, and after the
+model sits idle for the timeout it stops `llama-server` to free VRAM. The next
+inference request cold-starts the model and forwards once ready.
+
+Foreground-only by explicit decision — it keeps the surface small and is the
+right shape for containers/systemd. Desktop users background it themselves
+(`nohup`/`&`/tmux). No detached daemon, no `locca stop`/menu integration in v1.
+
+## Architecture
+
+One new module, `src/proxy.ts`. `serve.ts` wires the flag to it.
+
+```
+client → proxy :PORT (0.0.0.0)  ──forwards──▶  llama-server 127.0.0.1:PORT+1
+              │                                        ▲
+              ├─ idle > timeout & no in-flight ──────► SIGTERM (VRAM freed)
+              └─ inference request while down ───────► spawn + waitReady, then forward
+```
+
+### Ports
+- Proxy binds the user-facing port (`--port` / `cfg.defaultPort`) on host
+  `0.0.0.0` — so LAN / Tailscale work exactly as today.
+- `llama-server` moves to `port + 1`, bound to `127.0.0.1` only (internal, not
+  LAN-exposed).
+- If `port + 1` is already taken at startup, refuse with a clear message.
+
+### Reuse from `server.ts`
+- `buildServerArgs()` to construct the `llama-server` argv (varying only
+  host/port per respawn).
+- `waitReady()` to poll `/health` after each (re)launch.
+- The same `ServeOpts` `serve.ts` already computes — `ctx`, `threads`,
+  `noMmap`, `parallel`, `mmproj`, and `extraArgs` (`serverArgsForModel` +
+  `mtpArgsForModel`) — so a respawned model is byte-identical to the original
+  launch. `serve.ts` builds the `ServeOpts` once and hands them to the proxy.
+
+## Request routing
+
+| Endpoint | Cold-starts? | Resets idle? | When model is down |
+|---|---|---|---|
+| `GET /health` | no | no | proxy returns `200` (service up, just cold) |
+| `GET /v1/models` | no | no | synthesized list with the served model id |
+| `GET /props`, `GET /metrics` | no | no | proxy-through if up, else minimal / `503` |
+| everything else (inference) | **yes** | **yes** | held open → cold-start → forward |
+
+Only real inference resets the idle timer, so a Docker healthcheck or a status
+poll cannot keep the model pinned in VRAM.
+
+## Concurrency & lifecycle
+
+- State machine: `down → starting → up → stopping`. A single `ensureUp()`
+  promise — concurrent requests during a cold start all await the **one**
+  spawn; the model is never double-launched.
+- Idle reaper runs on an interval (every few seconds). It unloads only when
+  `inFlight === 0 && now - lastActivity > timeout` — an in-flight stream is
+  never cut mid-generation.
+- Request body is buffered in memory (chat/vision bodies are small for a
+  single-user local server) so it survives the cold-start wait. The response is
+  **streamed** through untouched, so SSE generations pass straight back.
+- The proxy's own response timeout is disabled so long generations and cold
+  starts are not severed.
+- Cold-start failure (model won't load): held requests get `503` with the
+  error; state resets so a later request retries.
+- `llama-server` crash while up: detected via child `exit`; marked down; the
+  next inference request reloads.
+- Ctrl-C / SIGTERM: stop `llama-server` (if up), then exit.
+
+## CLI surface
+
+- New flag: `--idle-timeout <duration>` (also `--idle-timeout=<duration>`).
+- Duration parsing: `30s`, `15m`, `1h`, or a bare integer (= seconds). Invalid
+  values are rejected with a clear message.
+- `--idle-timeout` implies the foreground proxy mode (it cannot detach).
+- `cli.ts` help text and README gain a short note, including the cold-start
+  latency caveat.
+
+## Caveat (documented)
+
+The first request after an unload pays the weights-load latency (10–30s on big
+models, per `waitReady`'s own comment). The proxy holds the connection open
+during the load; clients with aggressive timeouts may abandon that first cold
+request.
+
+## Scope
+
+**In:** the flag, `src/proxy.ts`, `serve.ts` wiring, `cli.ts` help text, README
+note.
+
+**Out (v1):** detached daemon mode; `locca stop` / interactive-menu
+integration; embedding-sidecar management under the proxy (foreground serve
+does not manage it today either); a persistent `idleTimeout` config key
+(flag-only for v1).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,9 @@ Inference:
                 --port/--ctx/--threads/--yes) it runs non-interactively — no
                 prompts. Add -f/--foreground to supervise it in the foreground
                 (logs to stdout, exits with the server — for Docker / systemd).
+                --idle-timeout <30s|15m|1h> runs a foreground proxy that frees
+                VRAM after the model is idle and reloads it on the next request
+                (first request after unload pays the cold-start latency).
   embed [name]  Start a dedicated embedding server (separate port)
   pi [name]     Launch pi coding agent with a local model
   switch        Stop current server and start a new model with pi

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -7,7 +7,15 @@ import { loadConfig } from '../config.js';
 import { requireLlama } from '../deps.js';
 import { findFirstMatch, pickModel, scanModels } from '../models.js';
 import { refuseIfPortTaken } from '../preflight.js';
-import { PIDFILE, launchServer, serverStatus, stopServer, waitReady } from '../server.js';
+import { parseDuration, runIdleProxy } from '../proxy.js';
+import {
+  PIDFILE,
+  type ServeOpts,
+  launchServer,
+  serverStatus,
+  stopServer,
+  waitReady,
+} from '../server.js';
 import type { Config, Model } from '../types.js';
 import { exitIfCancelled, pc } from '../ui.js';
 import { api } from './api.js';
@@ -26,6 +34,10 @@ interface ServeArgs {
   // detaching — logs stream to stdout, SIGTERM/Ctrl-C stops it cleanly, and
   // locca exits with the server. The right shape for a container's PID 1.
   foreground: boolean;
+  // Raw `--idle-timeout` value (e.g. "15m"). When set, serve runs the
+  // foreground idle-unload proxy instead of a plain launch. Parsed (and
+  // validated) in serve() so an invalid value reports a clear error.
+  idleTimeoutRaw?: string;
 }
 
 function parseServeArgs(rest: string[]): ServeArgs {
@@ -44,6 +56,9 @@ function parseServeArgs(rest: string[]): ServeArgs {
     else if (a.startsWith('--ctx=')) out.ctx = num(a.slice('--ctx='.length));
     else if (a === '--threads') out.threads = num(rest[++i]);
     else if (a.startsWith('--threads=')) out.threads = num(a.slice('--threads='.length));
+    else if (a === '--idle-timeout') out.idleTimeoutRaw = rest[++i];
+    else if (a.startsWith('--idle-timeout='))
+      out.idleTimeoutRaw = a.slice('--idle-timeout='.length);
     else if (!a.startsWith('-') && out.pattern === undefined) out.pattern = a;
   }
   return out;
@@ -105,8 +120,28 @@ export async function serve(rest: string[] = []): Promise<void> {
       }
     : await promptSettings(cfg);
 
+  // --idle-timeout switches serve into the foreground idle-unload proxy. Parse
+  // and validate here so a bad value fails fast with a helpful message.
+  let idleTimeout: number | undefined;
+  if (args.idleTimeoutRaw !== undefined) {
+    const sec = parseDuration(args.idleTimeoutRaw);
+    if (sec === null) {
+      p.log.error(
+        `Invalid --idle-timeout '${args.idleTimeoutRaw}' — use e.g. 30s, 15m, 1h, or a number of seconds.`,
+      );
+      process.exit(1);
+    }
+    idleTimeout = sec;
+  }
+
   await refuseIfPortTaken(port);
-  await launchModel(cfg, model, { port, ctx, threads, foreground: args.foreground });
+  await launchModel(cfg, model, {
+    port,
+    ctx,
+    threads,
+    foreground: args.foreground,
+    idleTimeout,
+  });
 }
 
 // Resolve the model in non-interactive mode. A pattern fuzzy-matches the full
@@ -194,11 +229,12 @@ async function launchModel(
     ctx,
     threads,
     foreground,
-  }: { port: number; ctx: number; threads: number; foreground: boolean },
+    idleTimeout,
+  }: { port: number; ctx: number; threads: number; foreground: boolean; idleTimeout?: number },
 ): Promise<void> {
-  printStartupBanner(model, port, ctx);
-
-  const child = launchServer({
+  // One launch template, reused for a plain launch and for every proxy respawn,
+  // so a reloaded model is byte-identical to the original.
+  const serveOpts: ServeOpts = {
     llamaServer: cfg.llamaServer,
     modelPath: model.path,
     mmprojPath: model.mmprojPath,
@@ -211,6 +247,27 @@ async function launchModel(
     ],
     noMmap: cfg.noMmap,
     parallel: cfg.defaultParallel,
+  };
+
+  // Idle-unload proxy: a foreground supervisor that frees VRAM after the model
+  // sits idle and cold-starts it on the next request. llama-server runs on the
+  // private internal port (proxy binds the user-facing one).
+  if (idleTimeout !== undefined) {
+    await runIdleProxy({
+      serveOpts,
+      publicHost: '0.0.0.0',
+      publicPort: port,
+      internalPort: port + 1,
+      idleSec: idleTimeout,
+      modelId: model.name,
+    });
+    return;
+  }
+
+  printStartupBanner(model, port, ctx);
+
+  const child = launchServer({
+    ...serveOpts,
     // Foreground → inherit stdio and block until the server exits; detached →
     // background the server and return so the api block can print.
     detached: !foreground,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,429 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import {
+  createServer,
+  type IncomingMessage,
+  request as httpRequest,
+  type ServerResponse,
+} from 'node:http';
+import { buildServerArgs, isPortInUse, type ServeOpts, waitReady } from './server.js';
+import { pc } from './ui.js';
+
+/**
+ * Parse an idle-timeout duration into seconds. Accepts `30s`, `15m`, `1h`, or a
+ * bare integer (treated as seconds). Returns null for anything unparseable or
+ * non-positive so the caller can reject with a clear message.
+ */
+export function parseDuration(s: string): number | null {
+  const m = /^(\d+)\s*(s|m|h)?$/i.exec(s.trim());
+  if (!m) return null;
+  const n = parseInt(m[1]!, 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const unit = (m[2] ?? 's').toLowerCase();
+  const mult = unit === 'h' ? 3600 : unit === 'm' ? 60 : 1;
+  return n * mult;
+}
+
+/** Render seconds back to a compact human string (`900` → `15m`, `90` → `90s`). */
+function fmtDuration(sec: number): string {
+  if (sec % 3600 === 0) return `${sec / 3600}h`;
+  if (sec % 60 === 0) return `${sec / 60}m`;
+  return `${sec}s`;
+}
+
+export interface IdleProxyOpts {
+  /**
+   * The launch template. `llamaServer`, `modelPath`, `ctx`, `threads`,
+   * `extraArgs`, `noMmap`, `parallel`, and `mmprojPath` are taken verbatim so a
+   * reloaded model is byte-identical to the original launch. `port`/`host`/
+   * `detached` are overridden per (re)spawn — llama-server always runs on the
+   * private internal port bound to 127.0.0.1.
+   */
+  serveOpts: ServeOpts;
+  /** Public-facing bind host (e.g. `0.0.0.0`) — same as a normal serve. */
+  publicHost: string;
+  /** Public-facing port the proxy listens on (the user's `--port`). */
+  publicPort: number;
+  /** Private port llama-server binds (127.0.0.1 only). Conventionally port+1. */
+  internalPort: number;
+  /** Idle window in seconds before the model is unloaded to free VRAM. */
+  idleSec: number;
+  /** Model id for the banner and synthesized `/v1/models` while unloaded. */
+  modelId: string;
+}
+
+// Hop-by-hop headers must not be forwarded across a proxy (RFC 7230 §6.1).
+// Node manages framing itself, so passing these through corrupts the stream.
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailers',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+function filterHeaders(h: NodeJS.Dict<string | string[]>): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  for (const [k, v] of Object.entries(h)) {
+    if (v === undefined) continue;
+    if (HOP_BY_HOP.has(k.toLowerCase())) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+const EMPTY = Buffer.alloc(0);
+
+/**
+ * Run llama-server behind a foreground reverse-proxy that unloads the model
+ * after `idleSec` of no inference, then cold-starts it on the next request.
+ *
+ * Lifecycle is a small state machine (`down → starting → up → stopping`).
+ * `ensureUp()` is single-flight: concurrent requests during a cold start all
+ * await the one spawn. The idle reaper only unloads when nothing is in flight,
+ * so a streaming generation is never cut. Resolves only on signal shutdown.
+ */
+export async function runIdleProxy(opts: IdleProxyOpts): Promise<void> {
+  const { serveOpts, publicHost, publicPort, internalPort, idleSec, modelId } = opts;
+  const idleMs = idleSec * 1000;
+
+  if (internalPort > 65535) {
+    fatal(`internal port ${internalPort} is out of range — pick a lower --port.`);
+  }
+  if (await isPortInUse(internalPort)) {
+    fatal(
+      `internal port ${internalPort} (used for the private llama-server) is already taken. ` +
+        'Free it or choose a different --port.',
+    );
+  }
+
+  type State = 'down' | 'starting' | 'up' | 'stopping';
+  let state: State = 'down';
+  let child: ChildProcess | null = null;
+  let startPromise: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
+  let lastActivity = Date.now();
+  let inFlight = 0;
+
+  const log = (msg: string) => console.log(`  ${pc.magenta('[locca]')} ${msg}`);
+
+  function spawnChild(): void {
+    const args = buildServerArgs({
+      ...serveOpts,
+      port: internalPort,
+      host: '127.0.0.1',
+      detached: false,
+    });
+    const c = spawn(serveOpts.llamaServer, args, { stdio: 'inherit' });
+    child = c;
+    c.on('error', (err) => log(pc.red(`failed to spawn llama-server: ${err.message}`)));
+    c.on('exit', (code, signal) => {
+      if (child !== c) return; // superseded by a newer child
+      if (state === 'stopping') return; // intentional — doStop() owns the transition
+      // Unexpected exit while we believed it was up/starting: mark down so the
+      // next inference request reloads it.
+      child = null;
+      state = 'down';
+      log(
+        pc.yellow(
+          `llama-server exited (code ${code ?? '-'}, signal ${signal ?? '-'}) — will reload on next request`,
+        ),
+      );
+    });
+  }
+
+  function doStart(): Promise<void> {
+    state = 'starting';
+    log(`loading ${pc.cyan(modelId)} …`);
+    spawnChild();
+    return waitReady(internalPort, 120).then((ok) => {
+      if (!ok || !child) {
+        try {
+          child?.kill('SIGKILL');
+        } catch {
+          // already gone
+        }
+        child = null;
+        state = 'down';
+        throw new Error('model did not become ready within 120s');
+      }
+      state = 'up';
+      log(pc.green('model ready'));
+    });
+  }
+
+  function ensureUp(): Promise<void> {
+    // A stop in progress must finish before we can (re)start cleanly.
+    const afterStop = stopPromise ? stopPromise.catch(() => {}) : Promise.resolve();
+    return afterStop.then(() => {
+      if (state === 'up') return;
+      if (startPromise) return startPromise;
+      startPromise = doStart().finally(() => {
+        startPromise = null;
+      });
+      return startPromise;
+    });
+  }
+
+  function doStop(): Promise<void> {
+    return new Promise((resolve) => {
+      const c = child;
+      if (!c) {
+        state = 'down';
+        resolve();
+        return;
+      }
+      const finish = () => {
+        child = null;
+        state = 'down';
+        resolve();
+      };
+      c.once('exit', finish);
+      try {
+        c.kill('SIGTERM');
+      } catch {
+        finish();
+        return;
+      }
+      // Hard-kill if it ignores SIGTERM.
+      setTimeout(() => {
+        try {
+          c.kill('SIGKILL');
+        } catch {
+          // already gone
+        }
+      }, 5000).unref();
+    });
+  }
+
+  function unload(): void {
+    if (state !== 'up' || inFlight > 0) return;
+    state = 'stopping';
+    log(pc.dim(`idle ${fmtDuration(idleSec)} — unloading model, freeing VRAM`));
+    stopPromise = doStop().finally(() => {
+      stopPromise = null;
+    });
+  }
+
+  // Keep llama-server alive for the duration of any upstream interaction so the
+  // reaper can't cut a request mid-flight. Only `touchIdle` requests (real
+  // inference) extend the idle deadline; metadata passthroughs don't.
+  function holdInFlight(res: ServerResponse, touchIdle: boolean): void {
+    inFlight++;
+    if (touchIdle) lastActivity = Date.now();
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      inFlight = Math.max(0, inFlight - 1);
+      if (touchIdle) lastActivity = Date.now();
+    };
+    res.on('close', release);
+    res.on('finish', release);
+  }
+
+  function proxyForward(req: IncomingMessage, res: ServerResponse, body: Buffer): void {
+    const headers = filterHeaders(req.headers);
+    headers.host = `127.0.0.1:${internalPort}`;
+    delete headers['content-length'];
+    if (body.length > 0) headers['content-length'] = String(body.length);
+
+    const upstream = httpRequest(
+      { host: '127.0.0.1', port: internalPort, method: req.method, path: req.url, headers },
+      (ur) => {
+        res.writeHead(ur.statusCode ?? 502, filterHeaders(ur.headers));
+        ur.pipe(res);
+      },
+    );
+    upstream.on('error', (err) => fail(res, 502, err));
+    // Client hung up — tear down the upstream request too.
+    res.on('close', () => {
+      if (!upstream.destroyed) upstream.destroy();
+    });
+    if (body.length > 0) upstream.write(body);
+    upstream.end();
+  }
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const method = (req.method ?? 'GET').toUpperCase();
+    const path = (req.url ?? '/').split('?')[0];
+
+    // /health: the service IS up (just possibly cold). Never wakes the model,
+    // never extends idle — so a healthcheck loop can't pin VRAM.
+    if (method === 'GET' && path === '/health') {
+      sendJson(res, 200, { status: 'ok' });
+      return;
+    }
+    // /v1/models: synthesize while unloaded so model-discovery doesn't reload.
+    if (method === 'GET' && path === '/v1/models') {
+      if (state === 'up') {
+        holdInFlight(res, false);
+        proxyForward(req, res, EMPTY);
+        return;
+      }
+      sendJson(res, 200, {
+        object: 'list',
+        data: [{ id: modelId, object: 'model', created: 0, owned_by: 'locca' }],
+      });
+      return;
+    }
+    // Other non-mutating requests (web UI, /props, /metrics): pass through when
+    // up, but never wake an unloaded model — only real inference should.
+    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+      if (state === 'up') {
+        holdInFlight(res, false);
+        proxyForward(req, res, EMPTY);
+        return;
+      }
+      sendText(res, 503, 'model unloaded (idle) — issue an inference request to reload\n');
+      return;
+    }
+
+    // Mutating request = inference. Cold-start if needed, count in-flight, and
+    // reset the idle clock. Body is buffered so it survives the cold-start wait.
+    holdInFlight(res, true);
+    let body: Buffer;
+    try {
+      body = await readBody(req);
+    } catch (e) {
+      fail(res, 400, e);
+      return;
+    }
+    try {
+      await ensureUp();
+    } catch (e) {
+      fail(res, 503, e);
+      return;
+    }
+    proxyForward(req, res, body);
+  }
+
+  const server = createServer((req, res) => {
+    handle(req, res).catch((err) => fail(res, 502, err));
+  });
+  // Don't let Node's request/response timeouts sever a long generation or a
+  // slow cold start — clients own their own timeouts.
+  server.requestTimeout = 0;
+  server.headersTimeout = 0;
+
+  banner(opts);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(publicPort, publicHost, () => resolve());
+  }).catch((err: NodeJS.ErrnoException) => {
+    fatal(`failed to bind ${publicHost}:${publicPort} — ${err.message}`);
+  });
+
+  // Eager load: serve should serve. A failure here is fatal, same as `serve`.
+  try {
+    await ensureUp();
+  } catch (e) {
+    fatal(`model failed to load: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  ready(publicPort, idleSec);
+
+  const tick = Math.max(1000, Math.min(5000, Math.floor(idleMs / 4)));
+  const reaper = setInterval(() => {
+    if (state === 'up' && inFlight === 0 && Date.now() - lastActivity > idleMs) unload();
+  }, tick);
+  reaper.unref();
+
+  await new Promise<void>((resolve) => {
+    let shuttingDown = false;
+    const shutdown = (sig: NodeJS.Signals) => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      console.log();
+      log(`${sig} — stopping`);
+      clearInterval(reaper);
+      server.close();
+      const c = child;
+      if (!c) {
+        resolve();
+        return;
+      }
+      c.once('exit', () => resolve());
+      try {
+        c.kill('SIGTERM');
+      } catch {
+        resolve();
+        return;
+      }
+      setTimeout(() => {
+        try {
+          c.kill('SIGKILL');
+        } catch {
+          // already gone
+        }
+        resolve();
+      }, 5000).unref();
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
+  });
+}
+
+function readBody(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, code: number, body: unknown): void {
+  if (res.headersSent) return;
+  res.writeHead(code, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function sendText(res: ServerResponse, code: number, body: string): void {
+  if (res.headersSent) return;
+  res.writeHead(code, { 'content-type': 'text/plain' });
+  res.end(body);
+}
+
+function fail(res: ServerResponse, code: number, err: unknown): void {
+  if (res.headersSent) {
+    try {
+      res.destroy();
+    } catch {
+      // already torn down
+    }
+    return;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  sendJson(res, code, { error: { message, type: 'locca_proxy' } });
+}
+
+function banner(opts: IdleProxyOpts): void {
+  console.log();
+  console.log(pc.magenta(pc.bold('  Starting server (idle-unload proxy)...')));
+  console.log(`  Model:        ${opts.modelId}`);
+  console.log(`  Port:         ${opts.publicPort} ${pc.dim('(proxy)')}`);
+  console.log(`  Internal:     127.0.0.1:${opts.internalPort} ${pc.dim('(llama-server)')}`);
+  console.log(`  Idle unload:  ${fmtDuration(opts.idleSec)}`);
+  console.log();
+}
+
+function ready(port: number, idleSec: number): void {
+  console.log();
+  console.log(
+    `  ${pc.green('●')} Serving at ${pc.cyan(`http://localhost:${port}/v1`)} ${pc.dim('(bound to 0.0.0.0)')}`,
+  );
+  console.log(
+    `  ${pc.dim(`Model unloads after ${fmtDuration(idleSec)} idle; first request after that reloads it (cold-start latency).`)}`,
+  );
+  console.log(`  ${pc.dim('Ctrl-C / SIGTERM to stop — server logs stream below')}`);
+  console.log();
+}
+
+function fatal(msg: string): never {
+  console.error(`  ${pc.red('✖')} ${msg}`);
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #13.

## What

Adds `locca serve <model> --idle-timeout <30s|15m|1h>`: a **foreground reverse-proxy** that loads the model eagerly, frees VRAM after the model sits idle for the timeout (by stopping `llama-server`), and transparently **cold-starts it on the next inference request**.

`llama-server` keeps weights resident for its whole lifetime — there's no native idle-unload — and locca's default `serve` spawns it detached and exits, so there's no resident process to catch a reload. This adds a small supervising proxy (the standard llama-swap-style approach) to bridge that gap, with zero new runtime dependencies (Node's built-in `http`).

## How it works

- Proxy binds the user-facing port (`--port`/`defaultPort`, `0.0.0.0`); `llama-server` runs privately on `port + 1` bound to `127.0.0.1`.
- State machine `down → starting → up → stopping`; single-flight `ensureUp()` coalesces concurrent cold starts so the model is never double-launched.
- Idle reaper unloads only when nothing is in flight — a streaming generation is never cut.
- **Only real inference** (mutating requests) cold-starts and resets the idle clock. `GET /health` → `200` and `GET /v1/models` → synthesized list are answered by the proxy, so a healthcheck or model-discovery poll can't pin the model in VRAM.
- Request body is buffered to survive the cold-start wait; the response **streams through untouched** (SSE passes straight back). Proxy response timeouts are disabled so long generations / cold starts aren't severed.
- Foreground-only by design (Ctrl-C / SIGTERM stops it cleanly). Reuses `buildServerArgs` / `waitReady` and the same `ServeOpts` `serve` already builds, so a reloaded model is byte-identical to the original launch.

## Scope

**In:** the flag, `src/proxy.ts`, `serve.ts` wiring, help text, README.
**Out (v1):** detached daemon mode, `locca stop`/menu integration, embedding-sidecar management under the proxy, a persistent `idleTimeout` config key.

## Caveat (documented)

The first request after an unload pays the weights-load latency (~10–30s on large models); the proxy holds the connection open during the reload, so clients with aggressive timeouts may abandon that first cold request.

## Verification

- `npm run build` (tsc strict) ✓; biome clean on all changed files (pre-existing `setup.ts` format errors untouched).
- Live smoke test (`LFM2.5-1.2B`, 15s timeout) confirmed the full lifecycle: **eager load → serve → idle-unload (VRAM freed, `llama-server` gone) → cold reload-on-demand returns a valid reply → 26-chunk SSE stream passes through → second idle cycle → clean SIGTERM**, no orphaned processes.

  ```
  [locca] loading LFM2.5-1.2B-Instruct-Q8_0 …
  [locca] model ready
  [locca] idle 15s — unloading model, freeing VRAM
  [locca] loading LFM2.5-1.2B-Instruct-Q8_0 …
  [locca] model ready
  [locca] idle 15s — unloading model, freeing VRAM
  [locca] SIGTERM — stopping
  ```

Design spec: `docs/superpowers/specs/2026-06-17-idle-timeout-proxy-design.md`.