### PR TITLE
feat(embed): --port/--ctx/--threads/--yes flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ in the foreground (Ctrl-C / SIGTERM stops it); background it yourself
 model reloads, so a client with an aggressive timeout may give up on that first
 cold request.
 
+## Embeddings
+
+`locca embed [model]` runs a **dedicated embedding server** on its own port
+(`defaultEmbedPort`, default `8090`), separate from the chat server so the two
+run side by side. Embedding models are auto-detected — by catalog entry, or
+names like `nomic-embed`, `bge`, `mxbai`, `e5`, `gte` — kept out of the `serve`
+picker and offered here instead. It launches `llama-server --embeddings
+--pooling <type>` (pooling is read from the catalog) and prints the
+OpenAI-compatible `/v1/embeddings` connection block.
+
+Like `serve`, it's head-less-friendly — a model name, `--yes`, or no TTY skips
+the picker, and `--port` / `--ctx` / `--threads` override the defaults:
+
+```
+locca embed nomic                            # match by name, detached
+locca embed nomic --port 8099 --ctx 4096     # explicit port + context
+locca embed --yes                            # no prompt: serve the sole embedding model
+```
+
+To run an embedding model **automatically alongside chat**, set
+`defaultEmbedModel` (a name pattern) in your config: `locca serve` then brings up
+the embedding sidecar on `defaultEmbedPort` after the chat server (best-effort —
+a sidecar failure never takes down chat), and `locca stop` stops both.
+`locca logs embed` tails the embedding server's log.
+
 ## Running in Docker
 
 The repo ships a `Dockerfile` and `docker-compose.yml` that run llama.cpp's
@@ -265,6 +290,7 @@ by hand, or re-run the wizard:
   "piContextFiles": false,
   "vramBudgetMB": 16384,
   "defaultParallel": 1,
+  "defaultEmbedPort": 8090,
   "noMmap": false
 }
 ```
@@ -322,6 +348,12 @@ improved stability** with mmap disabled. Not auto-detected on purpose:
 Strix Halo surfaces under several driver names
 (`Radeon 8050S/8060S`, `Radeon Graphics`, `RADV STRIX_HALO`), so a wrong
 guess would silently degrade.
+
+`defaultEmbedPort` (default `8090`) is the port for the dedicated embedding
+server — kept distinct from `defaultPort` so chat and embeddings run as two
+separate `llama-server` processes side by side. `defaultEmbedModel` is unset by
+default; set it to a model-name pattern and `locca serve` auto-starts that
+embedding model as a sidecar (see [Embeddings](#embeddings)).
 
 locca probes `defaultPort` at startup. If something already responds to
 `/health` (a llama-server you started by hand or via a supervisor),

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm link              # symlinks `locca` into your PATH
 locca                          # interactive menu (Pi is default)
 locca pi [model-pattern]       # launch pi against a local server
 locca serve [model] [opts]     # start llama-server — interactive, head-less, -f foreground, or --idle-timeout
-locca embed [model]            # start a dedicated embedding server (separate port)
+locca embed [model] [opts]     # dedicated embedding server (separate port); --port/--ctx/--threads/--yes
 locca switch                   # picker: installed models + curated catalog
 locca bench                    # run llama-bench against a model
 locca doctor                   # health check: hardware, llama.cpp, server, log, config

--- a/docs/index.html
+++ b/docs/index.html
@@ -1007,7 +1007,10 @@ median  pp <span class="ok">1851</span> t/s   tg <span class="ok">142</span> t/s
               dedicated embedding server on its own port, tuned with the
               <code translate="no">--pooling</code> and ubatch flags that
               <code translate="no">/v1/embeddings</code> needs — running side by
-              side with your chat model.
+              side with your chat model. Takes the same head-less
+              <code translate="no">--yes</code> and
+              <code translate="no">--port</code>/<code translate="no">--ctx</code>/<code translate="no">--threads</code>
+              flags as <code translate="no">serve</code>.
             </p>
           </div>
         </div>
@@ -1100,7 +1103,7 @@ Ask before anything destructive or anything needing sudo. If a step fails, show 
         <ul class="cmd-grid">
           <li class="cmd-row"><code translate="no">locca pi</code><span>Launch the pi coding agent against your local server.</span></li>
           <li class="cmd-row"><code translate="no">locca serve</code><span>Start <code translate="no" style="font-family:var(--mono)">llama-server</code> with a model — detached, head-less <code translate="no" style="font-family:var(--mono)">--yes</code>, foreground <code translate="no" style="font-family:var(--mono)">-f</code>, or <code translate="no" style="font-family:var(--mono)">--idle-timeout</code> to free VRAM when idle.</span></li>
-          <li class="cmd-row"><code translate="no">locca embed</code><span>Start a dedicated embedding server on its own port.</span></li>
+          <li class="cmd-row"><code translate="no">locca embed</code><span>Start a dedicated embedding server on its own port — head-less <code translate="no" style="font-family:var(--mono)">--yes</code> and <code translate="no" style="font-family:var(--mono)">--port</code>/<code translate="no" style="font-family:var(--mono)">--ctx</code>/<code translate="no" style="font-family:var(--mono)">--threads</code> overrides, like <code translate="no" style="font-family:var(--mono)">serve</code>.</span></li>
           <li class="cmd-row"><code translate="no">locca switch</code><span>Catalog-aware picker — installed models + curated catalog with fit hints.</span></li>
           <li class="cmd-row"><code translate="no">locca bench</code><span>Run llama-bench with a friendlier summary.</span></li>
           <li class="cmd-row"><code translate="no">locca doctor</code><span>Health check — hardware, server, log warnings, config sanity.</span></li>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,8 @@ Inference:
                 --idle-timeout <30s|15m|1h> runs a foreground proxy that frees
                 VRAM after the model is idle and reloads it on the next request
                 (first request after unload pays the cold-start latency).
-  embed [name]  Start a dedicated embedding server (separate port)
+  embed [name]  Start a dedicated embedding server (separate port). With a name
+                (+ optional --port/--ctx/--threads/--yes) it runs non-interactively.
   pi [name]     Launch pi coding agent with a local model
   switch        Stop current server and start a new model with pi
   stop          Stop running server(s)

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -22,18 +22,55 @@ import { api } from './api.js';
 // bge-m3; mxbai's 512 is honoured as-is.
 const EMBED_CTX_CAP = 8192;
 
+// Parsed `locca embed` invocation. Mirrors `serve`'s flag set (minus the
+// foreground / idle-timeout supervision options, which don't apply to the
+// short-lived embedding encoder). A positional pattern or `--yes` switches
+// embed into non-interactive mode — no Clack picker, suitable for scripts / CI.
+interface EmbedArgs {
+  pattern?: string;
+  port?: number;
+  ctx?: number;
+  threads?: number;
+  yes: boolean;
+}
+
+function parseEmbedArgs(rest: string[]): EmbedArgs {
+  const out: EmbedArgs = { yes: false };
+  const num = (s: string | undefined): number | undefined => {
+    const n = parseInt(s ?? '', 10);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--yes' || a === '-y') out.yes = true;
+    else if (a === '--port') out.port = num(rest[++i]);
+    else if (a.startsWith('--port=')) out.port = num(a.slice('--port='.length));
+    else if (a === '--ctx') out.ctx = num(rest[++i]);
+    else if (a.startsWith('--ctx=')) out.ctx = num(a.slice('--ctx='.length));
+    else if (a === '--threads') out.threads = num(rest[++i]);
+    else if (a.startsWith('--threads=')) out.threads = num(a.slice('--threads='.length));
+    else if (!a.startsWith('-') && out.pattern === undefined) out.pattern = a;
+  }
+  return out;
+}
+
 /**
  * `locca embed [model]` — start a dedicated embedding server on the embed port
  * (default 8090), independent of the chat server. Picks an embedding model
  * (filtered from `modelsDir`), launches llama-server with `--embeddings
  * --pooling <type>`, and prints the OpenAI-compatible connection info.
+ *
+ * A model name, `--yes`, or no TTY runs non-interactively (no picker), and
+ * `--port`/`--ctx`/`--threads` override the config / catalog defaults.
  */
-export async function embed(args: string[]): Promise<void> {
+export async function embed(argv: string[]): Promise<void> {
   const cfg = loadConfig();
-  const port = portForRole(cfg, 'embed');
-
-  // First positional may be a model name pattern (mirrors `locca pi <pattern>`).
-  const pattern = args[0] && !args[0].startsWith('-') ? args[0] : undefined;
+  const args = parseEmbedArgs(argv);
+  // A CLI `--port` wins over `defaultEmbedPort`. Used everywhere below except
+  // the status/stop check, which stays on the config role port (PID-based, so
+  // the swap still works) — exactly how `serve` treats its top-of-function
+  // status check vs `args.port`.
+  const port = args.port ?? portForRole(cfg, 'embed');
 
   // Resolve who's on the embed port before requiring llama-server.
   const status = await serverStatus(cfg, 'embed');
@@ -75,17 +112,18 @@ export async function embed(args: string[]): Promise<void> {
     );
   }
 
-  const model = pattern
-    ? findFirstMatch(pool, pattern)
+  // A pattern, `--yes`, or no TTY (a container, a pipe, CI) means "don't prompt
+  // me" — resolve from the pattern / sole embedding model instead of hanging on
+  // the picker.
+  const nonInteractive = args.pattern !== undefined || args.yes || !process.stdin.isTTY;
+  const model = nonInteractive
+    ? resolveEmbedModelNonInteractive(args, pool)
     : await pickModel(pool, 'Pick an embedding model');
-  if (!model) {
-    if (pattern) p.log.error(`No model matching '${pattern}'`);
-    return;
-  }
+  if (!model) return;
 
   await refuseIfPortTaken(port);
 
-  const ctx = launchEmbed(cfg, model, port);
+  const ctx = launchEmbed(cfg, model, port, { ctx: args.ctx, threads: args.threads });
 
   printStartupBanner(model, port, ctx);
 
@@ -106,15 +144,23 @@ export async function embed(args: string[]): Promise<void> {
  * Launch the embedding server (detached) for `model` on `port`. Shared by the
  * `embed` command and the `serve` sidecar. Returns the ctx it used.
  */
-export function launchEmbed(cfg: Config, model: Model, port: number): number {
+export function launchEmbed(
+  cfg: Config,
+  model: Model,
+  port: number,
+  overrides?: { ctx?: number; threads?: number },
+): number {
   const info = embeddingInfoForModel(basename(model.path));
-  const ctx = Math.min(info.ctxWindow ?? EMBED_CTX_CAP, EMBED_CTX_CAP);
+  // An explicit `--ctx` is honoured verbatim — it's a deliberate choice that
+  // also drives `--ubatch-size`/`--batch-size`. The bare command and the serve
+  // sidecar (no overrides) keep the safe EMBED_CTX_CAP clamp.
+  const ctx = overrides?.ctx ?? Math.min(info.ctxWindow ?? EMBED_CTX_CAP, EMBED_CTX_CAP);
   launchServer({
     llamaServer: cfg.llamaServer,
     modelPath: model.path,
     port,
     ctx,
-    threads: cfg.defaultThreads,
+    threads: overrides?.threads ?? cfg.defaultThreads,
     mode: 'embedding',
     pooling: info.pooling,
     role: 'embed',
@@ -168,6 +214,27 @@ export async function startEmbeddingSidecar(cfg: Config): Promise<string | null>
  *  sidecar must degrade gracefully, not kill the parent `serve`. */
 async function refuseIfPortTakenQuiet(port: number): Promise<boolean> {
   return isPortInUse(port);
+}
+
+// Resolve the embedding model in non-interactive mode. A pattern fuzzy-matches
+// the pool the same way `locca pi <pattern>` does; with no pattern (`--yes` or
+// no TTY) we serve the sole candidate if there's exactly one, else we refuse
+// rather than guess. Exits the process on any unresolvable case.
+function resolveEmbedModelNonInteractive(args: EmbedArgs, pool: Model[]): Model {
+  if (args.pattern !== undefined) {
+    const m = findFirstMatch(pool, args.pattern);
+    if (!m) {
+      p.log.error(`No model matching '${args.pattern}' in the models dir.`);
+      p.log.info(`Available: ${pool.map((c) => c.name).join(', ')}`);
+      process.exit(1);
+    }
+    return m;
+  }
+  // `--yes` / no TTY with no pattern: only unambiguous with a single candidate.
+  if (pool.length === 1) return pool[0];
+  p.log.error('Multiple embedding models found — pass a model pattern, e.g. `locca embed bge --yes`.');
+  p.log.info(`Available: ${pool.map((c) => c.name).join(', ')}`);
+  process.exit(1);
 }
 
 function printStartupBanner(model: Model, port: number, ctx: number): void {


### PR DESCRIPTION
## What

Adds `--port`, `--ctx`, `--threads`, and `--yes` to `locca embed`, bringing it to parity with `serve`'s non-interactive / tuning flags.

```
locca embed [name] [--port N] [--ctx N] [--threads N] [--yes]
```

## Why

`embed` accepted only a model-name pattern. Two gaps fell out of that:

- **Head-less launches** — with no pattern and no TTY (a container, a pipe, CI), `embed` fell through to the Clack picker and hung. There was no `--yes` to resolve the named or sole embedding model unattended.
- **Tuning** — the embed port (default 8090), context cap (`EMBED_CTX_CAP = 8192`), and thread count could only be changed by editing config.

## How

Mirrors the proven structure in `serve` (`parseServeArgs` + `resolveModelNonInteractive`):

- New `parseEmbedArgs()` — same four flags + positional.
- `nonInteractive = pattern || --yes || !isTTY` routes to a new `resolveEmbedModelNonInteractive()` (named/sole model, no prompt) instead of the picker.
- CLI `--port` is threaded through the clash check, `refuseIfPortTaken`, the banner, launch, and `waitReady`; the status/stop check stays on the config role port (PID-based, so the swap still works) — exactly as `serve` does.
- `launchEmbed()` gains an optional `{ctx, threads}` overrides arg. The `serve` embedding sidecar caller is unchanged and keeps the `EMBED_CTX_CAP` clamp; an explicit `--ctx` deliberately bypasses it (it also drives `--ubatch-size`/`--batch-size`).

**Out of scope** (deliberate): `-f/--foreground`, `--pooling`, `--idle-timeout`, and reranker serving.

## Verification

- `npm run build` clean (strict TS).
- `embed doesnotexist --yes` → "No model matching…" + exit 1.
- `embed nomic --port 8099 --ctx 4096 --threads 4 --yes` → launched on 8099, `/health` green, `/v1/embeddings` returned 768-dim vectors. Live process argv confirmed `--port 8099 --threads 4 --ctx-size 4096 --ubatch-size 4096 --batch-size 4096 --embeddings --pooling mean`.
- Sidecar path (`launchEmbed` without overrides) unchanged; interactive `embed` still shows the picker.

https://claude.ai/code/session_01BeeidykvgjAEth159MPUuE